### PR TITLE
Remember Streak and On This Day open/close state across sessions

### DIFF
--- a/main.js
+++ b/main.js
@@ -79,6 +79,16 @@
         				}
         			});
 
+        			['streak-details', 'otd-details'].forEach(id => {
+        				const details = document.getElementById(id);
+        				if (!details) return;
+        				const stored = localStorage.getItem(`sectionOpen:${id}`);
+        				if (stored !== null) details.open = stored === 'true';
+        				details.addEventListener('toggle', () => {
+        					localStorage.setItem(`sectionOpen:${id}`, details.open ? 'true' : 'false');
+        				});
+        			});
+
         			const [gamesRes, recordsRes, photosRes] = await Promise.all([
         				fetch('./data/packers_games.csv'),
         				fetch('./data/packers_season_records.csv'),


### PR DESCRIPTION
## Summary
- Persist the open/closed state of the "Streak" and "On This Day" collapsible sections in localStorage, so they stay how the user left them across visits
- Follows the existing `showEmojis` localStorage pattern; sections still default to open on first visit

## Testing
- Served the site locally and verified in a browser: collapsing either section survives a reload, and re-opening does too

🤖 Generated with [Claude Code](https://claude.com/claude-code)