### PR TITLE
Records & Superlatives page with per-record shareable cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When the override is active, a small reset link appears in the card header to cl
 
 ## Records & Superlatives
 
-`/records` is a standalone page of franchise superlatives computed from `data/packers_games.csv`: best season starts, perfect seasons, longest regular-season win streaks (ties end a streak), worst season starts, and most lopsided wins (playoffs included, flagged). Each superlative is its own shareable card with a deep link (`/records/best-starts`, `/records/perfect-seasons`, `/records/win-streaks`, `/records/worst-starts`, `/records/lopsided-wins`) and its own server-rendered social card at `/og/records/<slug>.png`, following the same pattern as the per-season cards.
+`/records` is a standalone page of franchise superlatives computed from `data/packers_games.csv`: best season starts, perfect seasons, longest regular-season win streaks (ties end a streak), worst season starts, most lopsided wins, and worst losses (blowouts include playoffs, flagged). Each superlative is its own shareable card with a deep link (`/records/best-starts`, `/records/perfect-seasons`, `/records/win-streaks`, `/records/worst-starts`, `/records/lopsided-wins`, `/records/worst-losses`) and its own server-rendered social card at `/og/records/<slug>.png`, following the same pattern as the per-season cards. Season years in the tables link to their season pages.
 
 The computation lives in `records-core.js`, a dependency-free module shared verbatim by the browser page (`records.html` + `records.js`) and the web service (`lib/records.js`), so the page and the link previews can never disagree.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When the override is active, a small reset link appears in the card header to cl
 
 ## Records & Superlatives
 
-`/records` is a standalone page of franchise superlatives computed from `data/packers_games.csv`: best season starts, perfect seasons, longest regular-season win streaks (ties end a streak), worst season starts, most lopsided wins, and worst losses (blowouts include playoffs, flagged). Each superlative is its own shareable card with a deep link (`/records/best-starts`, `/records/perfect-seasons`, `/records/win-streaks`, `/records/worst-starts`, `/records/lopsided-wins`, `/records/worst-losses`) and its own server-rendered social card at `/og/records/<slug>.png`, following the same pattern as the per-season cards. Season years in the tables link to their season pages.
+`/records` is a standalone page of franchise superlatives computed from `data/packers_games.csv`: best season starts, perfect seasons, longest regular-season win streaks (ties end a streak), worst season starts, most lopsided wins, worst losses (blowouts include playoffs, flagged), and a listing of every tie. Each superlative is its own shareable card with a deep link (`/records/best-starts`, `/records/perfect-seasons`, `/records/win-streaks`, `/records/worst-starts`, `/records/lopsided-wins`, `/records/worst-losses`, `/records/ties`) and its own server-rendered social card at `/og/records/<slug>.png`, following the same pattern as the per-season cards. Season years in the tables link to their season pages.
 
 The computation lives in `records-core.js`, a dependency-free module shared verbatim by the browser page (`records.html` + `records.js`) and the web service (`lib/records.js`), so the page and the link previews can never disagree.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ example.com/?otd=11-28
 
 When the override is active, a small reset link appears in the card header to clear it.
 
+## Records & Superlatives
+
+`/records` is a standalone page of franchise superlatives computed from `data/packers_games.csv`: best season starts, perfect seasons, longest regular-season win streaks (ties end a streak), worst season starts, and most lopsided wins (playoffs included, flagged). Each superlative is its own shareable card with a deep link (`/records/best-starts`, `/records/perfect-seasons`, `/records/win-streaks`, `/records/worst-starts`, `/records/lopsided-wins`) and its own server-rendered social card at `/og/records/<slug>.png`, following the same pattern as the per-season cards.
+
+The computation lives in `records-core.js`, a dependency-free module shared verbatim by the browser page (`records.html` + `records.js`) and the web service (`lib/records.js`), so the page and the link previews can never disagree.
+
 ## Data Files
 
 `data/packers_games.csv` — game-by-game results for every Packers game from 1921 to the present, including opponent, score, location, and playoff/Super Bowl flags. Pre-1999 rows come from the FiveThirtyEight source; 1999–present rows are sourced from nflverse-data.
@@ -103,8 +109,10 @@ The site is served by `server.js`, a small Node web service that:
 
 ```
 server.js            # web service (static serving + meta injection + card route)
-lib/cards.js         # SVG -> PNG card generator
+lib/cards.js         # SVG -> PNG card generator (seasons + records)
 lib/seasons.js       # per-season record from CSV + live ESPN feed
+lib/records.js       # records/superlatives data + meta for /records routes
+records-core.js      # shared superlative computation (browser + node)
 fonts/               # Liberation Sans (SIL OFL 1.1), bundled for deterministic rendering
 render.yaml          # Render Blueprint
 ```

--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
 
         <div id="last-undefeated" class="last-undefeated"></div>
 
+        <!-- /records.html works under both server.js (meta-injected, canonical=/records) and static dev servers -->
+        <a href="/records.html" class="share-btn records-link"><i class="mdi mdi-trophy-outline"></i> Records &amp; Superlatives</a>
+
         <div class="share-section">
             <button id="share-native" class="share-btn" hidden>
                 <i class="mdi mdi-share-variant share-icon"></i>

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -175,30 +175,33 @@ export function buildRecordsSvg(slug, data) {
         runners: [rest.map((w) => `0–${w.games} in ${w.season}`).join('  ·  ')],
       });
     }
-    case 'lopsided-wins': {
-      const [top, ...rest] = data.lopsidedWins;
+    case 'lopsided-wins':
+    case 'worst-losses': {
+      const win = slug === 'lopsided-wins';
+      const [top, ...rest] = win ? data.lopsidedWins : data.lopsidedLosses;
       const flag = (g) => (g.superbowl ? ', Super Bowl' : g.playoff ? ', playoffs' : '');
       return recordsFrame({
-        heading: 'MOST LOPSIDED WINS', range,
-        big: `${top.pf}–${top.pa}`,
+        heading: win ? 'MOST LOPSIDED WINS' : 'WORST LOSSES', range,
+        big: `${top.pf}–${top.pa}`, bigColor: win ? GOLD : WHITE,
         context: `vs the ${top.opponent} · ${formatDate(top.date)}${top.superbowl ? ' · Super Bowl' : top.playoff ? ' · Playoffs' : ''}`,
         runners: rest.slice(0, 2).map((g) => `${g.pf}–${g.pa} vs the ${g.opponent} (${g.season}${flag(g)})`),
       });
     }
     default: {
       const b = data.bestStarts[0], p = data.perfectSeasons[0], s = data.winStreaks[0],
-        w = data.worstStarts[0], g = data.lopsidedWins[0];
+        w = data.worstStarts[0], g = data.lopsidedWins[0], x = data.lopsidedLosses[0];
       const rows = [
         `Best start — ${b.games}–0 (${b.season})`,
         p ? `Perfect season — ${p.record} (${p.season})` : 'Perfect season — none. Yet.',
         `Longest win streak — ${s.games} straight (${streakSpan(s)})`,
         `Worst start — 0–${w.games} (${w.season})`,
         `Most lopsided win — ${g.pf}–${g.pa} vs ${g.opponent} (${g.season})`,
+        `Worst loss — ${x.pf}–${x.pa} vs ${x.opponent} (${x.season})`,
       ];
       return frame(
         title('RECORDS & SUPERLATIVES')
         + sub(168, `Green Bay Packers · ${range}`)
-        + rows.map((r, i) => line(262 + i * 62, r, i % 2 ? WHITE : GOLD, 34)).join('')
+        + rows.map((r, i) => line(250 + i * 52, r, i % 2 ? WHITE : GOLD, 34)).join('')
       );
     }
   }

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { Resvg } from '@resvg/resvg-js';
 import * as OT from 'opentype.js';
+import { formatDate, streakSpan, esc } from '../records-core.js';
 
 const opentype = OT.default ?? OT;
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -21,8 +22,6 @@ const WHITE = '#FFFFFF';
 const SUB = '#CFE8D6';
 const FONT = 'Liberation Sans';
 const CAP_RATIO = 106 / 150; // cap height / font size for Liberation Sans Bold
-
-const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 function football(cx, cy, w = 118, h = 72) {
   return `<g transform="translate(${cx},${cy})">
@@ -97,10 +96,114 @@ export function buildSvg(state) {
   }
 }
 
-export function renderPng(state) {
-  const resvg = new Resvg(buildSvg(state), {
+function toPng(svg) {
+  const resvg = new Resvg(svg, {
     fitTo: { mode: 'width', value: 1200 },
     font: { fontFiles: [BOLD, REGULAR], defaultFontFamily: FONT, loadSystemFonts: false },
   });
   return resvg.render().asPng();
+}
+
+export function renderPng(state) {
+  return toPng(buildSvg(state));
+}
+
+// --- Records & Superlatives cards ---
+
+const title = (text) =>
+  `<text x="600" y="120" font-family="${FONT}" font-size="58" font-weight="bold" fill="${GOLD}" text-anchor="middle" letter-spacing="2">${esc(text)}</text>`;
+const headline = (text, color = GOLD) =>
+  `<text x="600" y="345" font-family="${FONT}" font-size="130" font-weight="bold" fill="${color}" text-anchor="middle">${esc(text)}</text>`;
+
+// Standard records layout: title, season-range subtitle, big #1, context line,
+// then up to two runner-up lines.
+function recordsFrame({ heading, big, bigColor, context, runners, range }) {
+  const runnerLines = (runners || [])
+    .slice(0, 2)
+    .map((r, i) => sub(462 + i * 46, r))
+    .join('');
+  return frame(
+    title(heading)
+    + sub(168, `Green Bay Packers · ${range}`)
+    + headline(big, bigColor)
+    + line(408, context, WHITE, 34)
+    + runnerLines
+  );
+}
+
+// slug + data from records-core computeSuperlatives(); mirrors records.js copy.
+export function buildRecordsSvg(slug, data) {
+  const range = `${data.seasonRange.first}–${data.seasonRange.last}`;
+  switch (slug) {
+    case 'best-starts': {
+      const [top, ...rest] = data.bestStarts;
+      return recordsFrame({
+        heading: 'BEST SEASON STARTS', range,
+        big: `${top.games}–0`, context: `to open the ${top.season} season`,
+        runners: [rest.map((b) => `${b.games}–0 in ${b.season}`).join('  ·  ')],
+      });
+    }
+    case 'perfect-seasons': {
+      const [top, ...rest] = data.perfectSeasons;
+      if (!top) {
+        return frame(title('PERFECT SEASONS') + sub(168, `Green Bay Packers · ${range}`)
+          + line(360, 'None. Yet.', WHITE, 60));
+      }
+      return recordsFrame({
+        heading: 'PERFECT SEASONS', range,
+        big: top.record, context: `the ${top.season} season — no losses`,
+        runners: rest.length
+          ? [rest.map((p) => `${p.record} in ${p.season}`).join('  ·  ')]
+          : ['The only one in franchise history.'],
+      });
+    }
+    case 'win-streaks': {
+      const [top, ...rest] = data.winStreaks;
+      return recordsFrame({
+        heading: 'LONGEST WIN STREAKS', range,
+        big: `${top.games} straight`,
+        context: `${formatDate(top.startDate)} – ${formatDate(top.endDate)}`,
+        runners: [rest.map((s) => `${s.games} in ${streakSpan(s)}`).join('  ·  ')],
+      });
+    }
+    case 'worst-starts': {
+      const [top, ...rest] = data.worstStarts;
+      return recordsFrame({
+        heading: 'WORST SEASON STARTS', range,
+        big: `0–${top.games}`, bigColor: WHITE,
+        context: `to open the ${top.season} season`,
+        runners: [rest.map((w) => `0–${w.games} in ${w.season}`).join('  ·  ')],
+      });
+    }
+    case 'lopsided-wins': {
+      const [top, ...rest] = data.lopsidedWins;
+      const flag = (g) => (g.superbowl ? ', Super Bowl' : g.playoff ? ', playoffs' : '');
+      return recordsFrame({
+        heading: 'MOST LOPSIDED WINS', range,
+        big: `${top.pf}–${top.pa}`,
+        context: `vs the ${top.opponent} · ${formatDate(top.date)}${top.superbowl ? ' · Super Bowl' : top.playoff ? ' · Playoffs' : ''}`,
+        runners: rest.slice(0, 2).map((g) => `${g.pf}–${g.pa} vs the ${g.opponent} (${g.season}${flag(g)})`),
+      });
+    }
+    default: {
+      const b = data.bestStarts[0], p = data.perfectSeasons[0], s = data.winStreaks[0],
+        w = data.worstStarts[0], g = data.lopsidedWins[0];
+      const rows = [
+        `Best start — ${b.games}–0 (${b.season})`,
+        p ? `Perfect season — ${p.record} (${p.season})` : 'Perfect season — none. Yet.',
+        `Longest win streak — ${s.games} straight (${streakSpan(s)})`,
+        `Worst start — 0–${w.games} (${w.season})`,
+        `Most lopsided win — ${g.pf}–${g.pa} vs ${g.opponent} (${g.season})`,
+      ];
+      return frame(
+        title('RECORDS & SUPERLATIVES')
+        + sub(168, `Green Bay Packers · ${range}`)
+        + rows.map((r, i) => line(262 + i * 62, r, i % 2 ? WHITE : GOLD, 34)).join('')
+      );
+    }
+  }
+}
+
+export function renderRecordsPng(slug, data) {
+  return toPng(buildRecordsSvg(slug, data));
 }

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -187,6 +187,16 @@ export function buildRecordsSvg(slug, data) {
         runners: rest.slice(0, 2).map((g) => `${g.pf}–${g.pa} vs the ${g.opponent} (${g.season}${flag(g)})`),
       });
     }
+    case 'ties': {
+      const [latest] = data.ties;
+      const preOT = data.ties.filter((t) => t.season < 1974).length;
+      return recordsFrame({
+        heading: 'TIES', range,
+        big: String(data.ties.length),
+        context: latest ? `most recent: ${latest.pf}–${latest.pa} vs the ${latest.opponent} · ${formatDate(latest.date)}` : 'never happened',
+        runners: [`${preOT} of them came before overtime arrived in 1974`],
+      });
+    }
     default: {
       const b = data.bestStarts[0], p = data.perfectSeasons[0], s = data.winStreaks[0],
         w = data.worstStarts[0], g = data.lopsidedWins[0], x = data.lopsidedLosses[0];
@@ -197,11 +207,12 @@ export function buildRecordsSvg(slug, data) {
         `Worst start — 0–${w.games} (${w.season})`,
         `Most lopsided win — ${g.pf}–${g.pa} vs ${g.opponent} (${g.season})`,
         `Worst loss — ${x.pf}–${x.pa} vs ${x.opponent} (${x.season})`,
+        `Ties — ${data.ties.length}, most recent in ${data.ties[0] ? data.ties[0].season : 'never'}`,
       ];
       return frame(
         title('RECORDS & SUPERLATIVES')
         + sub(168, `Green Bay Packers · ${range}`)
-        + rows.map((r, i) => line(250 + i * 52, r, i % 2 ? WHITE : GOLD, 34)).join('')
+        + rows.map((r, i) => line(240 + i * 48, r, i % 2 ? WHITE : GOLD, 34)).join('')
       );
     }
   }

--- a/lib/records.js
+++ b/lib/records.js
@@ -1,0 +1,16 @@
+// Server-side records/superlatives: computed once at startup from the same
+// parsed CSV rows lib/seasons.js loads. Pure computation lives in
+// records-core.js (shared with the browser page).
+import { computeSuperlatives, recordsCopy, RECORD_SLUGS } from '../records-core.js';
+import { allGames } from './seasons.js';
+
+export const records = computeSuperlatives(allGames);
+
+export function isRecordSlug(slug) {
+	return RECORD_SLUGS.includes(slug);
+}
+
+// slug undefined/'overview' -> landing-page copy.
+export function recordsMeta(slug) {
+	return recordsCopy(slug || 'overview', records);
+}

--- a/lib/seasons.js
+++ b/lib/seasons.js
@@ -3,32 +3,17 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { parseGamesCsv } from '../records-core.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CSV = join(__dirname, '..', 'data', 'packers_games.csv');
 const ESPN = 'https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/gb/schedule';
 
-function splitCsvLine(line) {
-  const out = []; let cur = ''; let q = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === '"') { if (q && line[i + 1] === '"') { cur += '"'; i++; } else q = !q; }
-    else if (ch === ',' && !q) { out.push(cur); cur = ''; }
-    else cur += ch;
-  }
-  out.push(cur);
-  return out.map((s) => s.trim());
-}
+// Single read+parse of the games CSV for the whole process; lib/records.js
+// consumes the same rows.
+const allGames = parseGamesCsv(readFileSync(CSV, 'utf8'));
 
-function loadCsv() {
-  const raw = readFileSync(CSV, 'utf8').trim();
-  const lines = raw.split('\n');
-  const headers = splitCsvLine(lines[0]);
-  const rows = lines.slice(1).map((l) => {
-    const v = splitCsvLine(l); const o = {};
-    headers.forEach((h, i) => { o[h] = v[i] ?? ''; });
-    return o;
-  });
+function indexBySeason(rows) {
   const bySeason = new Map();
   let maxSeason = 0;
   for (const r of rows) {
@@ -41,7 +26,7 @@ function loadCsv() {
   return { bySeason, maxSeason };
 }
 
-const { bySeason, maxSeason } = loadCsv();
+const { bySeason, maxSeason } = indexBySeason(allGames);
 
 const rec = (w, l, t) => (t > 0 ? `${w}-${l}-${t}` : `${w}-${l}`);
 
@@ -160,4 +145,4 @@ export async function getSeasonState(season) {
   }
 }
 
-export { maxSeason };
+export { maxSeason, allGames };

--- a/main.js
+++ b/main.js
@@ -1,44 +1,5 @@
-        function parseCsv(raw) {
-        	const lines = raw.trim().split('\n');
-        	const headers = lines[0].split(',');
-        	return lines.slice(1).map(line => {
-        		const vals = line.split(',');
-        		const obj = {};
-        		headers.forEach((h, i) => { obj[h.trim()] = (vals[i] || '').trim(); });
-        		return obj;
-        	});
-        }
-
-        function parseCsvQuoted(raw) {
-        	const lines = raw.trim().split('\n');
-        	const headers = splitCsvLine(lines[0]);
-        	return lines.slice(1).map(line => {
-        		const vals = splitCsvLine(line);
-        		const obj = {};
-        		headers.forEach((h, i) => { obj[h] = (vals[i] || ''); });
-        		return obj;
-        	});
-        }
-
-        function splitCsvLine(line) {
-        	const result = [];
-        	let cur = '';
-        	let inQuotes = false;
-        	for (let i = 0; i < line.length; i++) {
-        		const ch = line[i];
-        		if (ch === '"') {
-        			if (inQuotes && line[i + 1] === '"') { cur += '"'; i++; }
-        			else inQuotes = !inQuotes;
-        		} else if (ch === ',' && !inQuotes) {
-        			result.push(cur.trim());
-        			cur = '';
-        		} else {
-        			cur += ch;
-        		}
-        	}
-        	result.push(cur.trim());
-        	return result;
-        }
+        import { parseGamesCsv } from './records-core.js';
+        import { intentUrls, copyText, flashCopied } from './share-core.js';
 
         function buildSeasonMap(games) {
         	const map = {};
@@ -96,7 +57,7 @@
         			]);
         			if (gamesRes.ok) {
         				const raw = await gamesRes.text();
-        				const games = parseCsv(raw);
+        				const games = parseGamesCsv(raw);
         				this.csvBySeason = buildSeasonMap(games);
         				const seasons = Object.keys(this.csvBySeason).map(Number).sort((a, b) => a - b);
         				if (seasons.length) {
@@ -106,13 +67,13 @@
         			}
         			if (recordsRes.ok) {
         				const raw = await recordsRes.text();
-        				parseCsv(raw).forEach(r => {
+        				parseGamesCsv(raw).forEach(r => {
         					this.seasonRecords[parseInt(r.season)] = r;
         				});
         			}
         			if (photosRes.ok) {
         				const raw = await photosRes.text();
-        				parseCsvQuoted(raw).forEach(p => {
+        				parseGamesCsv(raw).forEach(p => {
         					const yr = parseInt(p.season);
         					if (!this.photosBySeason[yr]) this.photosBySeason[yr] = [];
         					this.photosBySeason[yr].push(p);
@@ -1076,18 +1037,11 @@ getShareMessage() {
 }
 
 updateIntentLinks() {
-  const message = this.getShareMessage();
-  const url = window.location.href;
-  const shareText = `${message}\n\n${url}`;
-
-  const xBtn = document.getElementById('share-x');
-  const bskyBtn = document.getElementById('share-bsky');
-  const fbBtn = document.getElementById('share-fb');
-  const redditBtn = document.getElementById('share-reddit');
-  if (xBtn) xBtn.href = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`;
-  if (bskyBtn) bskyBtn.href = `https://bsky.app/intent/compose?text=${encodeURIComponent(shareText)}`;
-  if (fbBtn) fbBtn.href = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(message)}`;
-  if (redditBtn) redditBtn.href = `https://www.reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(message)}`;
+  const links = intentUrls(this.getShareMessage(), window.location.href);
+  for (const [key, id] of [['x', 'share-x'], ['bsky', 'share-bsky'], ['fb', 'share-fb'], ['reddit', 'share-reddit']]) {
+    const btn = document.getElementById(id);
+    if (btn) btn.href = links[key];
+  }
 }
 
 async nativeShare() {
@@ -1102,38 +1056,11 @@ async nativeShare() {
 
 async copyLink() {
     const copyBtn = document.getElementById('share-copy');
-    const message = this.getShareMessage();
-    const url = window.location.href;
-    const shareText = `${message}\n\nCheck it out: ${url}`;
-    
+    const shareText = `${this.getShareMessage()}\n\nCheck it out: ${window.location.href}`;
         // Flash FIRST, synchronously on click, so feedback never depends on the
         // clipboard call succeeding or on a permission prompt.
-    if (this._copyOriginalHTML == null) this._copyOriginalHTML = copyBtn.innerHTML;
-    if (this._copyFlashTimer) clearTimeout(this._copyFlashTimer);
-    copyBtn.innerHTML = '<i class="mdi mdi-check share-icon"></i>Copied!';
-    copyBtn.classList.add('copy-success');
-    this._copyFlashTimer = setTimeout(() => {
-        copyBtn.innerHTML = this._copyOriginalHTML;
-        copyBtn.classList.remove('copy-success');
-        this._copyFlashTimer = null;
-    }, 2000);
-    
-        // Then actually copy (with a legacy fallback for older/insecure contexts).
-    try {
-        await navigator.clipboard.writeText(shareText);
-    } catch (_) {
-        try {
-            const ta = document.createElement('textarea');
-            ta.value = shareText;
-            ta.style.position = 'fixed';
-            ta.style.opacity = '0';
-            document.body.appendChild(ta);
-            ta.focus();
-            ta.select();
-            document.execCommand('copy');
-            document.body.removeChild(ta);
-        } catch (_) {}
-    }
+    flashCopied(copyBtn, '<i class="mdi mdi-check share-icon"></i>Copied!');
+    await copyText(shareText);
 }
 
 buildOnThisDay() {

--- a/records-core.js
+++ b/records-core.js
@@ -1,0 +1,191 @@
+// Shared (browser + node) computation of Packers records/superlatives from
+// data/packers_games.csv. Pure functions only — no fs/fetch/DOM.
+
+export function splitCsvLine(line) {
+	const out = []; let cur = ''; let q = false;
+	for (let i = 0; i < line.length; i++) {
+		const ch = line[i];
+		if (ch === '"') { if (q && line[i + 1] === '"') { cur += '"'; i++; } else q = !q; }
+		else if (ch === ',' && !q) { out.push(cur); cur = ''; }
+		else cur += ch;
+	}
+	out.push(cur);
+	return out.map((s) => s.trim());
+}
+
+export function parseGamesCsv(raw) {
+	const lines = raw.trim().split('\n');
+	const headers = splitCsvLine(lines[0]);
+	return lines.slice(1).map((l) => {
+		const v = splitCsvLine(l); const o = {};
+		headers.forEach((h, i) => { o[h] = v[i] ?? ''; });
+		return o;
+	});
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// 'YYYY-MM-DD' -> 'Oct 23, 1966' without Date() timezone pitfalls.
+export function formatDate(iso) {
+	const [y, m, d] = iso.split('-').map((n) => parseInt(n, 10));
+	return `${MONTHS[m - 1]} ${d}, ${y}`;
+}
+
+const rec = (w, l, t) => (t > 0 ? `${w}–${l}–${t}` : `${w}–${l}`);
+
+export const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+const RESULTS = new Set(['WIN', 'LOSS', 'TIE']);
+
+// A season labelled Y runs into Jan/Feb of Y+1; by March 1 of Y+1 it is over.
+// Guards "perfect season" claims against the mid-season CSV updates the weekly
+// data workflow commits (an unbeaten October team hasn't finished anything).
+const seasonSettled = (yr, now) =>
+	now.getFullYear() > yr + 1 || (now.getFullYear() === yr + 1 && now.getMonth() >= 2);
+
+// rows: parsed CSV rows. Returns { seasonRange, bestStarts, perfectSeasons,
+// winStreaks, worstStarts, lopsidedWins } — each list sorted best-first,
+// trimmed to `top`. Streaks/starts/perfect seasons are regular season only;
+// ties end win streaks (record-book convention). Lopsided wins include
+// playoffs, flagged.
+export function computeSuperlatives(rows, { top = 5, now = new Date() } = {}) {
+	const games = rows
+		.filter((r) => RESULTS.has(r['Packers Win']))
+		.slice()
+		.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+	const regular = games.filter((r) => r.regular_season === '1');
+
+	const seasons = new Map(); // year -> chronological regular-season games
+	for (const g of regular) {
+		const yr = parseInt(g.season, 10);
+		if (!seasons.has(yr)) seasons.set(yr, []);
+		seasons.get(yr).push(g);
+	}
+	const years = [...seasons.keys()].sort((a, b) => a - b);
+	const seasonRange = { first: years[0], last: years[years.length - 1] };
+
+	// Leading run of `result` games to open each season.
+	const seasonStarts = (result) => {
+		const out = [];
+		for (const yr of years) {
+			let n = 0;
+			for (const g of seasons.get(yr)) {
+				if (g['Packers Win'] === result) n++;
+				else break;
+			}
+			if (n > 0) out.push({ season: yr, games: n });
+		}
+		return out.sort((a, b) => b.games - a.games || a.season - b.season).slice(0, top);
+	};
+	const bestStarts = seasonStarts('WIN');
+	const worstStarts = seasonStarts('LOSS');
+
+	const perfectSeasons = [];
+	for (const yr of years) {
+		let w = 0, l = 0, t = 0;
+		for (const g of seasons.get(yr)) {
+			if (g['Packers Win'] === 'WIN') w++;
+			else if (g['Packers Win'] === 'LOSS') l++;
+			else t++;
+		}
+		if (l === 0 && w > 0 && seasonSettled(yr, now)) perfectSeasons.push({ season: yr, wins: w, record: rec(w, l, t) });
+	}
+	perfectSeasons.sort((a, b) => b.wins - a.wins || a.season - b.season);
+
+	// Regular-season win streaks, allowed to span seasons; a loss or tie ends one.
+	const winStreaks = [];
+	let run = null;
+	const endRun = () => { if (run) { winStreaks.push(run); run = null; } };
+	for (const g of regular) {
+		if (g['Packers Win'] === 'WIN') {
+			if (!run) run = { games: 0, start: null, end: null };
+			run.games++;
+			if (!run.start) run.start = g;
+			run.end = g;
+		} else {
+			endRun();
+		}
+	}
+	endRun();
+	const streakEntry = (s) => ({
+		games: s.games,
+		startDate: s.start.date, endDate: s.end.date,
+		startSeason: parseInt(s.start.season, 10), endSeason: parseInt(s.end.season, 10),
+	});
+	const topStreaks = winStreaks
+		.sort((a, b) => b.games - a.games || (a.start.date < b.start.date ? -1 : 1))
+		.slice(0, top)
+		.map(streakEntry);
+
+	const lopsidedWins = games
+		.filter((g) => g['Packers Win'] === 'WIN')
+		.map((g) => {
+			const pf = parseInt(g.packers_score, 10) || 0;
+			const pa = parseInt(g.opponent_score, 10) || 0;
+			return {
+				date: g.date, season: parseInt(g.season, 10), opponent: g.Opponent,
+				pf, pa,
+				playoff: g.regular_season !== '1',
+				superbowl: !!(g.superbowl && g.superbowl.trim()),
+			};
+		})
+		.sort((a, b) => (b.pf - b.pa) - (a.pf - a.pa) || b.pf - a.pf || (a.date < b.date ? -1 : 1))
+		.slice(0, top);
+
+	return { seasonRange, bestStarts, perfectSeasons, winStreaks: topStreaks, worstStarts, lopsidedWins };
+}
+
+export const streakSpan = (s) =>
+	s.startSeason === s.endSeason ? String(s.startSeason) : `${s.startSeason}–${s.endSeason}`;
+
+// Per-card copy shared by server OG meta and client share messages.
+// slug 'overview' covers the /records landing URL.
+export function recordsCopy(slug, data) {
+	const range = `${data.seasonRange.first}–${data.seasonRange.last}`;
+	switch (slug) {
+		case 'best-starts': {
+			const b = data.bestStarts[0];
+			return {
+				title: `Best Packers Season Starts — ${b.games}–0 in ${b.season}`,
+				desc: `The best start in Green Bay Packers history: ${b.games}–0 to open the ${b.season} season. Top ${data.bestStarts.length} starts, ${range}.`,
+			};
+		}
+		case 'perfect-seasons': {
+			const p = data.perfectSeasons[0];
+			return {
+				title: p ? `Perfect Packers Seasons — ${p.record} in ${p.season}` : 'Perfect Packers Seasons',
+				desc: p
+					? `Seasons the Green Bay Packers finished without a loss: ${data.perfectSeasons.map((x) => `${x.record} in ${x.season}`).join(', ')}.`
+					: 'No Packers season has finished without a loss. Yet.',
+			};
+		}
+		case 'win-streaks': {
+			const s = data.winStreaks[0];
+			return {
+				title: `Longest Packers Win Streaks — ${s.games} straight (${streakSpan(s)})`,
+				desc: `The longest regular-season win streak in Green Bay Packers history: ${s.games} straight, ${formatDate(s.startDate)} to ${formatDate(s.endDate)}.`,
+			};
+		}
+		case 'worst-starts': {
+			const w = data.worstStarts[0];
+			return {
+				title: `Worst Packers Season Starts — 0–${w.games} in ${w.season}`,
+				desc: `The worst start in Green Bay Packers history: 0–${w.games} to open the ${w.season} season. It happens to the best of us.`,
+			};
+		}
+		case 'lopsided-wins': {
+			const g = data.lopsidedWins[0];
+			return {
+				title: `Most Lopsided Packers Wins — ${g.pf}–${g.pa} over the ${g.opponent}`,
+				desc: `The biggest blowout in Green Bay Packers history: ${g.pf}–${g.pa} over the ${g.opponent} on ${formatDate(g.date)}.`,
+			};
+		}
+		default:
+			return {
+				title: 'Packers Records & Superlatives',
+				desc: `Best starts, perfect seasons, longest win streaks, worst starts, and most lopsided wins — Green Bay Packers, ${range}.`,
+			};
+	}
+}
+
+export const RECORD_SLUGS = ['best-starts', 'perfect-seasons', 'win-streaks', 'worst-starts', 'lopsided-wins'];

--- a/records-core.js
+++ b/records-core.js
@@ -117,27 +117,32 @@ export function computeSuperlatives(rows, { top = 5, now = new Date() } = {}) {
 		.slice(0, top)
 		.map(streakEntry);
 
+	const gameInfo = (g) => {
+		const pf = parseInt(g.packers_score, 10) || 0;
+		const pa = parseInt(g.opponent_score, 10) || 0;
+		return {
+			date: g.date, season: parseInt(g.season, 10), opponent: g.Opponent,
+			pf, pa,
+			playoff: g.regular_season !== '1',
+			superbowl: !!(g.superbowl && g.superbowl.trim()),
+		};
+	};
+
 	// Biggest margins, either direction; sort by margin, then winner's score, then date.
 	const lopsided = (result) => games
 		.filter((g) => g['Packers Win'] === result)
-		.map((g) => {
-			const pf = parseInt(g.packers_score, 10) || 0;
-			const pa = parseInt(g.opponent_score, 10) || 0;
-			return {
-				date: g.date, season: parseInt(g.season, 10), opponent: g.Opponent,
-				pf, pa,
-				playoff: g.regular_season !== '1',
-				superbowl: !!(g.superbowl && g.superbowl.trim()),
-			};
-		})
+		.map(gameInfo)
 		.sort((a, b) => Math.abs(b.pf - b.pa) - Math.abs(a.pf - a.pa)
 			|| Math.max(b.pf, b.pa) - Math.max(a.pf, a.pa)
 			|| (a.date < b.date ? -1 : 1))
 		.slice(0, top);
 
+	// Every tie ever, not a top-N list; newest first.
+	const ties = games.filter((g) => g['Packers Win'] === 'TIE').map(gameInfo).reverse();
+
 	return {
 		seasonRange, bestStarts, perfectSeasons, winStreaks: topStreaks, worstStarts,
-		lopsidedWins: lopsided('WIN'), lopsidedLosses: lopsided('LOSS'),
+		lopsidedWins: lopsided('WIN'), lopsidedLosses: lopsided('LOSS'), ties,
 	};
 }
 
@@ -193,12 +198,20 @@ export function recordsCopy(slug, data) {
 				desc: `The most lopsided loss in Green Bay Packers history: ${g.pa}–${g.pf} to the ${g.opponent} on ${formatDate(g.date)}. We don't talk about it.`,
 			};
 		}
+		case 'ties': {
+			const t = data.ties[0];
+			if (!t) return { title: 'Packers Ties', desc: 'The Packers have never tied a game.' };
+			return {
+				title: `Packers Ties — ${data.ties.length} all-time`,
+				desc: `The Packers have played ${data.ties.length} ties. Most recent: ${t.pf}–${t.pa} vs the ${t.opponent} on ${formatDate(t.date)}.`,
+			};
+		}
 		default:
 			return {
 				title: 'Packers Records & Superlatives',
-				desc: `Best starts, perfect seasons, longest win streaks, worst starts, lopsided wins, and worst losses — Green Bay Packers, ${range}.`,
+				desc: `Best starts, perfect seasons, longest win streaks, worst starts, lopsided wins, worst losses, and every tie — Green Bay Packers, ${range}.`,
 			};
 	}
 }
 
-export const RECORD_SLUGS = ['best-starts', 'perfect-seasons', 'win-streaks', 'worst-starts', 'lopsided-wins', 'worst-losses'];
+export const RECORD_SLUGS = ['best-starts', 'perfect-seasons', 'win-streaks', 'worst-starts', 'lopsided-wins', 'worst-losses', 'ties'];

--- a/records-core.js
+++ b/records-core.js
@@ -117,8 +117,9 @@ export function computeSuperlatives(rows, { top = 5, now = new Date() } = {}) {
 		.slice(0, top)
 		.map(streakEntry);
 
-	const lopsidedWins = games
-		.filter((g) => g['Packers Win'] === 'WIN')
+	// Biggest margins, either direction; sort by margin, then winner's score, then date.
+	const lopsided = (result) => games
+		.filter((g) => g['Packers Win'] === result)
 		.map((g) => {
 			const pf = parseInt(g.packers_score, 10) || 0;
 			const pa = parseInt(g.opponent_score, 10) || 0;
@@ -129,10 +130,15 @@ export function computeSuperlatives(rows, { top = 5, now = new Date() } = {}) {
 				superbowl: !!(g.superbowl && g.superbowl.trim()),
 			};
 		})
-		.sort((a, b) => (b.pf - b.pa) - (a.pf - a.pa) || b.pf - a.pf || (a.date < b.date ? -1 : 1))
+		.sort((a, b) => Math.abs(b.pf - b.pa) - Math.abs(a.pf - a.pa)
+			|| Math.max(b.pf, b.pa) - Math.max(a.pf, a.pa)
+			|| (a.date < b.date ? -1 : 1))
 		.slice(0, top);
 
-	return { seasonRange, bestStarts, perfectSeasons, winStreaks: topStreaks, worstStarts, lopsidedWins };
+	return {
+		seasonRange, bestStarts, perfectSeasons, winStreaks: topStreaks, worstStarts,
+		lopsidedWins: lopsided('WIN'), lopsidedLosses: lopsided('LOSS'),
+	};
 }
 
 export const streakSpan = (s) =>
@@ -180,12 +186,19 @@ export function recordsCopy(slug, data) {
 				desc: `The biggest blowout in Green Bay Packers history: ${g.pf}–${g.pa} over the ${g.opponent} on ${formatDate(g.date)}.`,
 			};
 		}
+		case 'worst-losses': {
+			const g = data.lopsidedLosses[0];
+			return {
+				title: `Worst Packers Losses — ${g.pf}–${g.pa} to the ${g.opponent}`,
+				desc: `The most lopsided loss in Green Bay Packers history: ${g.pa}–${g.pf} to the ${g.opponent} on ${formatDate(g.date)}. We don't talk about it.`,
+			};
+		}
 		default:
 			return {
 				title: 'Packers Records & Superlatives',
-				desc: `Best starts, perfect seasons, longest win streaks, worst starts, and most lopsided wins — Green Bay Packers, ${range}.`,
+				desc: `Best starts, perfect seasons, longest win streaks, worst starts, lopsided wins, and worst losses — Green Bay Packers, ${range}.`,
 			};
 	}
 }
 
-export const RECORD_SLUGS = ['best-starts', 'perfect-seasons', 'win-streaks', 'worst-starts', 'lopsided-wins'];
+export const RECORD_SLUGS = ['best-starts', 'perfect-seasons', 'win-streaks', 'worst-starts', 'lopsided-wins', 'worst-losses'];

--- a/records.html
+++ b/records.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Packers Records &amp; Superlatives</title>
+    <meta name="description" content="Best starts, perfect seasons, longest win streaks, worst starts, and most lopsided wins in Green Bay Packers history.">
+    <meta property="og:title" content="Packers Records &amp; Superlatives">
+    <meta property="og:description" content="Best starts, perfect seasons, longest win streaks, worst starts, and most lopsided wins in Green Bay Packers history.">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
+    <!-- Absolute asset paths: this shell is also served at /records/<slug>, where relative paths would break. -->
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="container records-container">
+        <a href="/" class="records-back"><i class="mdi mdi-arrow-left"></i> Are the Packers Undefeated?</a>
+        <h1 class="records-title">Records &amp; Superlatives</h1>
+        <p id="records-subtitle" class="records-subtitle"></p>
+        <div id="records-grid" class="records-grid">
+            <div class="loading">Loading records...</div>
+        </div>
+    </div>
+
+    <footer class="site-footer">
+        <a href="https://github.com/rptetzloff/AreThePackersUndefeated" target="_blank" rel="noopener noreferrer" class="github-link">
+            <i class="mdi mdi-github"></i>
+            View on GitHub
+        </a>
+    </footer>
+
+    <script src="/records.js" type="module"></script>
+</body>
+</html>

--- a/records.js
+++ b/records.js
@@ -50,6 +50,12 @@ const CARDS = [
 		note: 'Biggest margins of defeat, playoffs included',
 		entries: (d) => d.lopsidedLosses.map(blowoutEntry),
 	},
+	{
+		slug: 'ties', icon: 'mdi-equal', title: 'Ties',
+		note: 'Every tie in franchise history, most recent first — overtime arrived in 1974',
+		entries: (d) => d.ties.map(blowoutEntry),
+		empty: 'The Packers have never tied a game.',
+	},
 ];
 
 function entryHtml(e, i) {

--- a/records.js
+++ b/records.js
@@ -1,0 +1,152 @@
+// Records & Superlatives page: computes superlatives from the games CSV
+// (records-core.js, shared with the server) and renders one shareable card each.
+import { parseGamesCsv, computeSuperlatives, recordsCopy, formatDate, streakSpan, RECORD_SLUGS, esc } from './records-core.js';
+
+const CARDS = [
+	{
+		slug: 'best-starts', icon: 'mdi-rocket-launch-outline', title: 'Best Season Starts',
+		note: 'Wins to open a season',
+		entries: (d) => d.bestStarts.map((b) => ({ main: `${b.games}–0`, sub: String(b.season) })),
+	},
+	{
+		slug: 'perfect-seasons', icon: 'mdi-trophy-outline', title: 'Perfect Seasons',
+		note: 'Finished the regular season without a loss',
+		entries: (d) => d.perfectSeasons.map((p) => ({ main: p.record, sub: String(p.season) })),
+		empty: 'No perfect seasons. Yet.',
+	},
+	{
+		slug: 'win-streaks', icon: 'mdi-fire', title: 'Longest Win Streaks',
+		note: 'Consecutive regular-season wins (ties end a streak)',
+		entries: (d) => d.winStreaks.map((s) => ({
+			main: `${s.games} straight`, sub: streakSpan(s),
+			detail: `${formatDate(s.startDate)} – ${formatDate(s.endDate)}`,
+		})),
+	},
+	{
+		slug: 'worst-starts', icon: 'mdi-trending-down', title: 'Worst Season Starts',
+		note: 'Losses to open a season',
+		entries: (d) => d.worstStarts.map((w) => ({ main: `0–${w.games}`, sub: String(w.season) })),
+	},
+	{
+		slug: 'lopsided-wins', icon: 'mdi-scoreboard-outline', title: 'Most Lopsided Wins',
+		note: 'Biggest margins of victory, playoffs included',
+		entries: (d) => d.lopsidedWins.map((g) => ({
+			main: `${g.pf}–${g.pa}`, sub: `vs ${g.opponent}`,
+			detail: formatDate(g.date) + (g.superbowl ? ' · Super Bowl' : g.playoff ? ' · Playoffs' : ''),
+		})),
+	},
+];
+
+function entryHtml(e, i) {
+	return `<li class="record-entry${i === 0 ? ' record-entry-top' : ''}">
+		<span class="record-entry-main">${esc(e.main)}</span>
+		<span class="record-entry-sub">${esc(e.sub)}</span>
+		${e.detail ? `<span class="record-entry-detail">${esc(e.detail)}</span>` : ''}
+	</li>`;
+}
+
+function shareRowHtml(slug) {
+	const native = !!navigator.share;
+	const alts = native ? '' : `
+		<a class="share-btn record-share-btn" data-share="x" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on X"><i class="mdi mdi-twitter"></i></a>
+		<a class="share-btn record-share-btn" data-share="bsky" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Bluesky"><i class="mdi mdi-butterfly"></i></a>
+		<a class="share-btn record-share-btn" data-share="fb" href="#" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook"><i class="mdi mdi-facebook"></i></a>
+		<a class="share-btn record-share-btn" data-share="reddit" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Reddit"><i class="mdi mdi-reddit"></i></a>`;
+	return `<div class="record-share" data-slug="${slug}">
+		${native ? '<button class="share-btn record-share-btn" data-share="native" aria-label="Share"><i class="mdi mdi-share-variant"></i></button>' : ''}
+		${alts}
+		<button class="share-btn record-share-btn" data-share="copy" aria-label="Copy link"><i class="mdi mdi-clipboard-outline"></i></button>
+	</div>`;
+}
+
+function cardHtml(card, data) {
+	const entries = card.entries(data);
+	const body = entries.length
+		? `<ol class="record-list">${entries.map(entryHtml).join('')}</ol>`
+		: `<p class="record-empty">${esc(card.empty || 'Nothing here yet.')}</p>`;
+	return `<section class="record-card" id="card-${card.slug}">
+		<h2 class="record-card-title"><i class="mdi ${card.icon}"></i> ${esc(card.title)}</h2>
+		<p class="record-note">${esc(card.note)}</p>
+		${body}
+		${shareRowHtml(card.slug)}
+	</section>`;
+}
+
+function shareUrl(slug) {
+	return `${window.location.origin}/records/${slug}`;
+}
+
+function wireShares(grid, data) {
+	grid.querySelectorAll('.record-share').forEach((row) => {
+		const slug = row.dataset.slug;
+		const url = shareUrl(slug);
+		const message = recordsCopy(slug, data).desc;
+		const text = `${message}\n\n${url}`;
+		row.querySelectorAll('[data-share]').forEach((btn) => {
+			switch (btn.dataset.share) {
+				case 'x': btn.href = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`; break;
+				case 'bsky': btn.href = `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`; break;
+				case 'fb': btn.href = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(message)}`; break;
+				case 'reddit': btn.href = `https://www.reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(message)}`; break;
+				case 'native':
+					btn.addEventListener('click', async () => {
+						try { await navigator.share({ text: message, url }); } catch { /* user cancelled */ }
+					});
+					break;
+				case 'copy':
+					btn.addEventListener('click', async () => {
+						try { await navigator.clipboard.writeText(text); }
+						catch {
+							const ta = document.createElement('textarea');
+							ta.value = text;
+							ta.style.cssText = 'position:fixed;opacity:0';
+							document.body.appendChild(ta);
+							ta.select();
+							document.execCommand('copy');
+							ta.remove();
+						}
+						const original = btn.innerHTML;
+						btn.innerHTML = '<i class="mdi mdi-check"></i>';
+						btn.classList.add('copy-success');
+						setTimeout(() => { btn.innerHTML = original; btn.classList.remove('copy-success'); }, 2000);
+					});
+					break;
+			}
+		});
+	});
+}
+
+// /records/<slug> deep link (or ?card=<slug> when served statically in dev).
+function requestedSlug() {
+	const m = window.location.pathname.match(/\/records\/([a-z-]+)\/?$/);
+	const slug = m ? m[1] : new URLSearchParams(window.location.search).get('card');
+	return RECORD_SLUGS.includes(slug) ? slug : null;
+}
+
+async function init() {
+	const grid = document.getElementById('records-grid');
+	try {
+		const res = await fetch('/data/packers_games.csv');
+		if (!res.ok) throw new Error(`CSV fetch failed: ${res.status}`);
+		const data = computeSuperlatives(parseGamesCsv(await res.text()));
+		document.getElementById('records-subtitle').textContent =
+			`Green Bay Packers · ${data.seasonRange.first}–${data.seasonRange.last}`;
+		grid.innerHTML = CARDS.map((c) => cardHtml(c, data)).join('');
+		wireShares(grid, data);
+
+		const slug = requestedSlug();
+		if (slug) {
+			document.title = recordsCopy(slug, data).title;
+			const card = document.getElementById(`card-${slug}`);
+			if (card) {
+				card.classList.add('record-card-focus');
+				card.scrollIntoView({ block: 'center' });
+			}
+		}
+	} catch (e) {
+		grid.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
+		console.error(e);
+	}
+}
+
+init();

--- a/records.js
+++ b/records.js
@@ -1,47 +1,64 @@
 // Records & Superlatives page: computes superlatives from the games CSV
 // (records-core.js, shared with the server) and renders one shareable card each.
-import { parseGamesCsv, computeSuperlatives, recordsCopy, formatDate, streakSpan, RECORD_SLUGS, esc } from './records-core.js';
+import { parseGamesCsv, computeSuperlatives, recordsCopy, formatDate, RECORD_SLUGS, esc } from './records-core.js';
+import { intentUrls, copyText, flashCopied } from './share-core.js';
+
+const yearLink = (yr) => `<a href="/${yr}">${yr}</a>`;
+const gameFlag = (g) => (g.superbowl ? ' · Super Bowl' : g.playoff ? ' · Playoffs' : '');
+// Blowout entries link the date to the game's season page (a January playoff
+// game belongs to the prior year's season, so the season, not the date's year).
+const blowoutEntry = (g) => ({
+	main: `${g.pf}–${g.pa}`, sub: `vs ${g.opponent}`,
+	detailHtml: `<a href="/${g.season}">${esc(formatDate(g.date))}</a>${esc(gameFlag(g))}`,
+});
 
 const CARDS = [
 	{
 		slug: 'best-starts', icon: 'mdi-rocket-launch-outline', title: 'Best Season Starts',
 		note: 'Wins to open a season',
-		entries: (d) => d.bestStarts.map((b) => ({ main: `${b.games}–0`, sub: String(b.season) })),
+		entries: (d) => d.bestStarts.map((b) => ({ main: `${b.games}–0`, subHtml: yearLink(b.season) })),
 	},
 	{
 		slug: 'perfect-seasons', icon: 'mdi-trophy-outline', title: 'Perfect Seasons',
 		note: 'Finished the regular season without a loss',
-		entries: (d) => d.perfectSeasons.map((p) => ({ main: p.record, sub: String(p.season) })),
+		entries: (d) => d.perfectSeasons.map((p) => ({ main: p.record, subHtml: yearLink(p.season) })),
 		empty: 'No perfect seasons. Yet.',
 	},
 	{
 		slug: 'win-streaks', icon: 'mdi-fire', title: 'Longest Win Streaks',
 		note: 'Consecutive regular-season wins (ties end a streak)',
 		entries: (d) => d.winStreaks.map((s) => ({
-			main: `${s.games} straight`, sub: streakSpan(s),
+			main: `${s.games} straight`,
+			subHtml: s.startSeason === s.endSeason
+				? yearLink(s.startSeason)
+				: `${yearLink(s.startSeason)}–${yearLink(s.endSeason)}`,
 			detail: `${formatDate(s.startDate)} – ${formatDate(s.endDate)}`,
 		})),
 	},
 	{
 		slug: 'worst-starts', icon: 'mdi-trending-down', title: 'Worst Season Starts',
 		note: 'Losses to open a season',
-		entries: (d) => d.worstStarts.map((w) => ({ main: `0–${w.games}`, sub: String(w.season) })),
+		entries: (d) => d.worstStarts.map((w) => ({ main: `0–${w.games}`, subHtml: yearLink(w.season) })),
 	},
 	{
 		slug: 'lopsided-wins', icon: 'mdi-scoreboard-outline', title: 'Most Lopsided Wins',
 		note: 'Biggest margins of victory, playoffs included',
-		entries: (d) => d.lopsidedWins.map((g) => ({
-			main: `${g.pf}–${g.pa}`, sub: `vs ${g.opponent}`,
-			detail: formatDate(g.date) + (g.superbowl ? ' · Super Bowl' : g.playoff ? ' · Playoffs' : ''),
-		})),
+		entries: (d) => d.lopsidedWins.map(blowoutEntry),
+	},
+	{
+		slug: 'worst-losses', icon: 'mdi-thumb-down-outline', title: 'Worst Losses',
+		note: 'Biggest margins of defeat, playoffs included',
+		entries: (d) => d.lopsidedLosses.map(blowoutEntry),
 	},
 ];
 
 function entryHtml(e, i) {
+	const sub = e.subHtml ?? esc(e.sub);
+	const detail = e.detailHtml ?? (e.detail ? esc(e.detail) : '');
 	return `<li class="record-entry${i === 0 ? ' record-entry-top' : ''}">
 		<span class="record-entry-main">${esc(e.main)}</span>
-		<span class="record-entry-sub">${esc(e.sub)}</span>
-		${e.detail ? `<span class="record-entry-detail">${esc(e.detail)}</span>` : ''}
+		<span class="record-entry-sub">${sub}</span>
+		${detail ? `<span class="record-entry-detail">${detail}</span>` : ''}
 	</li>`;
 }
 
@@ -72,43 +89,27 @@ function cardHtml(card, data) {
 	</section>`;
 }
 
-function shareUrl(slug) {
-	return `${window.location.origin}/records/${slug}`;
-}
-
 function wireShares(grid, data) {
 	grid.querySelectorAll('.record-share').forEach((row) => {
 		const slug = row.dataset.slug;
-		const url = shareUrl(slug);
+		const url = `${window.location.origin}/records/${slug}`;
 		const message = recordsCopy(slug, data).desc;
-		const text = `${message}\n\n${url}`;
+		const links = intentUrls(message, url);
 		row.querySelectorAll('[data-share]').forEach((btn) => {
 			switch (btn.dataset.share) {
-				case 'x': btn.href = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`; break;
-				case 'bsky': btn.href = `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`; break;
-				case 'fb': btn.href = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(message)}`; break;
-				case 'reddit': btn.href = `https://www.reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(message)}`; break;
+				case 'x': btn.href = links.x; break;
+				case 'bsky': btn.href = links.bsky; break;
+				case 'fb': btn.href = links.fb; break;
+				case 'reddit': btn.href = links.reddit; break;
 				case 'native':
 					btn.addEventListener('click', async () => {
 						try { await navigator.share({ text: message, url }); } catch { /* user cancelled */ }
 					});
 					break;
 				case 'copy':
-					btn.addEventListener('click', async () => {
-						try { await navigator.clipboard.writeText(text); }
-						catch {
-							const ta = document.createElement('textarea');
-							ta.value = text;
-							ta.style.cssText = 'position:fixed;opacity:0';
-							document.body.appendChild(ta);
-							ta.select();
-							document.execCommand('copy');
-							ta.remove();
-						}
-						const original = btn.innerHTML;
-						btn.innerHTML = '<i class="mdi mdi-check"></i>';
-						btn.classList.add('copy-success');
-						setTimeout(() => { btn.innerHTML = original; btn.classList.remove('copy-success'); }, 2000);
+					btn.addEventListener('click', () => {
+						flashCopied(btn, '<i class="mdi mdi-check"></i>');
+						copyText(`${message}\n\n${url}`);
 					});
 					break;
 			}

--- a/server.js
+++ b/server.js
@@ -8,21 +8,14 @@ import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, extname } from 'node:path';
-import { renderPng } from './lib/cards.js';
+import { renderPng, renderRecordsPng } from './lib/cards.js';
 import { getSeasonState, defaultSeason } from './lib/seasons.js';
+import { records, recordsMeta, isRecordSlug } from './lib/records.js';
+import { esc } from './records-core.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
 const PORT = process.env.PORT || 3000;
-const RAW_INDEX = readFileSync(join(ROOT, 'index.html'), 'utf8');
-// Strip any hardcoded <title>/description/OG/Twitter/canonical tags so the
-// server is the single source of truth and pages never ship duplicate,
-// conflicting meta (a static og:url=root will otherwise override per-season tags).
-const INDEX = [
-  /<title>[\s\S]*?<\/title>\s*/i,
-  /<meta[^>]*\b(?:property=["']og:[^"']*["']|name=["']twitter:[^"']*["']|name=["']description["'])[^>]*>\s*/gi,
-  /<link[^>]*\brel=["']canonical["'][^>]*>\s*/gi,
-].reduce((html, re) => html.replace(re, ''), RAW_INDEX);
 
 // Stamp a short content hash onto local asset refs so a new deploy busts the
 // browser cache automatically (main.js?v=<hash>). Change the file -> new hash.
@@ -30,13 +23,31 @@ function assetVersion(file) {
   try { return createHash('sha1').update(readFileSync(join(ROOT, file))).digest('hex').slice(0, 8); }
   catch { return null; }
 }
-const INDEX_VERSIONED = ['main.js', 'styles.css'].reduce((html, asset) => {
-  const v = assetVersion(asset);
-  if (!v) return html;
-  return html
-    .replace(`src="${asset}"`, `src="${asset}?v=${v}"`)
-    .replace(`href="${asset}"`, `href="${asset}?v=${v}"`);
-}, INDEX);
+
+// Load an HTML shell: strip any hardcoded <title>/description/OG/Twitter/
+// canonical tags so the server is the single source of truth and pages never
+// ship duplicate, conflicting meta (a static og:url will otherwise override
+// per-URL tags), then version the given local assets (relative or /-rooted).
+function loadShell(file, assets) {
+  const raw = readFileSync(join(ROOT, file), 'utf8');
+  const stripped = [
+    /<title>[\s\S]*?<\/title>\s*/i,
+    /<meta[^>]*\b(?:property=["']og:[^"']*["']|name=["']twitter:[^"']*["']|name=["']description["'])[^>]*>\s*/gi,
+    /<link[^>]*\brel=["']canonical["'][^>]*>\s*/gi,
+  ].reduce((html, re) => html.replace(re, ''), raw);
+  return assets.reduce((html, asset) => {
+    const v = assetVersion(asset);
+    if (!v) return html;
+    for (const attr of ['src', 'href']) {
+      html = html
+        .replace(`${attr}="${asset}"`, `${attr}="${asset}?v=${v}"`)
+        .replace(`${attr}="/${asset}"`, `${attr}="/${asset}?v=${v}"`);
+    }
+    return html;
+  }, stripped);
+}
+const INDEX_VERSIONED = loadShell('index.html', ['main.js', 'styles.css']);
+const RECORDS_VERSIONED = loadShell('records.html', ['records.js', 'styles.css']);
 
 const MIME = {
   '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
@@ -45,8 +56,6 @@ const MIME = {
   '.svg': 'image/svg+xml', '.ico': 'image/x-icon', '.webmanifest': 'application/manifest+json',
   '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf', '.txt': 'text/plain; charset=utf-8',
 };
-
-const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
 function copy(state) {
   const s = state.season;
@@ -71,9 +80,7 @@ function copy(state) {
   }
 }
 
-function metaTags(state, origin, canonical) {
-  const { title, desc } = copy(state);
-  const img = `${origin}/og/${state.season}.png`;
+function metaBlock({ title, desc, img, canonical }) {
   return `
     <title>${esc(title)}</title>
     <meta name="description" content="${esc(desc)}">
@@ -98,6 +105,17 @@ function originOf(req) {
   return `${proto}://${host}`;
 }
 
+function notFound(res) {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Not found');
+}
+
+function sendPage(res, shell, meta) {
+  const html = shell.replace('</head>', `${metaBlock(meta)}\n</head>`);
+  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
+  res.end(html);
+}
+
 async function serveHtml(req, res, season) {
   const origin = originOf(req);
   const state = await getSeasonState(season);
@@ -105,9 +123,30 @@ async function serveHtml(req, res, season) {
   // string (Facebook/X append ?fbclid=, ?utm_*), and never fall back to root
   // for a season page, or crawlers will canonicalize the whole thing away.
   const canonical = season ? `${origin}/${state.season}` : `${origin}/`;
-  const html = INDEX_VERSIONED.replace('</head>', `${metaTags(state, origin, canonical)}\n</head>`);
-  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
-  res.end(html);
+  const { title, desc } = copy(state);
+  sendPage(res, INDEX_VERSIONED, { title, desc, img: `${origin}/og/${state.season}.png`, canonical });
+}
+
+// /records and /records/<slug>: same shell, per-slug meta + social card.
+function serveRecordsHtml(req, res, slug) {
+  const origin = originOf(req);
+  const { title, desc } = recordsMeta(slug);
+  const canonical = slug ? `${origin}/records/${slug}` : `${origin}/records`;
+  const img = `${origin}/og/records/${slug || 'overview'}.png`;
+  sendPage(res, RECORDS_VERSIONED, { title, desc, img, canonical });
+}
+
+// Records data is fixed for the lifetime of the process (CSV is read at
+// startup; updates arrive via redeploy), so render each card at most once.
+const recordsImgCache = new Map(); // slug -> buf
+function serveRecordsImage(res, slug) {
+  let buf = recordsImgCache.get(slug);
+  if (!buf) {
+    buf = renderRecordsPng(slug, records);
+    recordsImgCache.set(slug, buf);
+  }
+  res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=3600' });
+  res.end(buf);
 }
 
 const imgCache = new Map(); // season -> { buf, at }
@@ -140,18 +179,22 @@ async function serveStatic(req, res, pathname) {
     if (st.isDirectory()) throw new Error('dir');
     const body = await readFile(file);
     const versioned = /[?&]v=/.test(req.url);
+    const ext = extname(file).toLowerCase();
+    // Unversioned JS (module imports like records-core.js can't carry ?v=)
+    // must revalidate on every load, or a deploy can pair a fresh versioned
+    // entry module with an hour-stale dependency.
+    const cache = versioned ? 'public, max-age=31536000, immutable'
+      : ext === '.js' ? 'no-cache'
+      : 'public, max-age=3600';
     res.writeHead(200, {
-      'Content-Type': MIME[extname(file).toLowerCase()] || 'application/octet-stream',
-      'Cache-Control': versioned ? 'public, max-age=31536000, immutable' : 'public, max-age=3600',
+      'Content-Type': MIME[ext] || 'application/octet-stream',
+      'Cache-Control': cache,
     });
     res.end(body);
   } catch {
     // Real assets (paths with a file extension) that don't exist must 404 —
     // returning HTML for a missing .png/.ico/.txt confuses crawlers (esp. Twitterbot).
-    if (extname(pathname)) {
-      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-      return res.end('Not found');
-    }
+    if (extname(pathname)) return notFound(res);
     // Extension-less route: serve the app shell with default meta (SPA fallback).
     await serveHtml(req, res, undefined);
   }
@@ -161,6 +204,12 @@ const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url, 'http://x');
     const pathname = decodeURIComponent(url.pathname);
+
+    const ogRec = pathname.match(/^\/og\/records\/([a-z-]+)\.png$/);
+    if (ogRec) {
+      if (ogRec[1] !== 'overview' && !isRecordSlug(ogRec[1])) return notFound(res);
+      return serveRecordsImage(res, ogRec[1]);
+    }
 
     const img = pathname.match(/^\/og\/(\d{4})\.png$/);
     if (img) return await serveImage(req, res, parseInt(img[1], 10));
@@ -178,6 +227,16 @@ const server = http.createServer(async (req, res) => {
     }
     const yr = pathname.match(/^\/(\d{4})\/?$/);
     if (yr) return await serveHtml(req, res, parseInt(yr[1], 10));
+
+    if (pathname === '/records' || pathname === '/records/' || pathname === '/records.html')
+      return serveRecordsHtml(req, res, undefined);
+    if (pathname.startsWith('/records/')) {
+      // Only exact known slugs get the page; anything else (bad case, extra
+      // segments) must 404, not fall through to the homepage SPA fallback.
+      const slug = pathname.slice('/records/'.length).replace(/\/$/, '');
+      if (!isRecordSlug(slug)) return notFound(res);
+      return serveRecordsHtml(req, res, slug);
+    }
 
     return await serveStatic(req, res, pathname);
   } catch (e) {

--- a/share-core.js
+++ b/share-core.js
@@ -1,0 +1,48 @@
+// Shared share-button helpers for the browser pages (main.js and records.js):
+// share-intent URL builders and copy-to-clipboard with visual flash feedback.
+
+export function intentUrls(message, url) {
+	const text = `${message}\n\n${url}`;
+	return {
+		x: `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`,
+		bsky: `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`,
+		fb: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(message)}`,
+		reddit: `https://www.reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(message)}`,
+	};
+}
+
+// Flash a button into its "copied" state for 2s, restoring its original
+// content afterwards. Safe to call repeatedly (re-clicks reset the timer).
+const flashState = new WeakMap(); // btn -> { original, timer }
+export function flashCopied(btn, flashHtml) {
+	let st = flashState.get(btn);
+	if (!st) { st = { original: btn.innerHTML, timer: null }; flashState.set(btn, st); }
+	if (st.timer) clearTimeout(st.timer);
+	btn.innerHTML = flashHtml;
+	btn.classList.add('copy-success');
+	st.timer = setTimeout(() => {
+		btn.innerHTML = st.original;
+		btn.classList.remove('copy-success');
+		st.timer = null;
+	}, 2000);
+}
+
+// Copy text to the clipboard, with a legacy fallback for older/insecure
+// contexts. Never throws — callers flash feedback before calling this.
+export async function copyText(text) {
+	try {
+		await navigator.clipboard.writeText(text);
+	} catch (_) {
+		try {
+			const ta = document.createElement('textarea');
+			ta.value = text;
+			ta.style.position = 'fixed';
+			ta.style.opacity = '0';
+			document.body.appendChild(ta);
+			ta.focus();
+			ta.select();
+			document.execCommand('copy');
+			document.body.removeChild(ta);
+		} catch (_) {}
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -1264,6 +1264,18 @@ details:not([open]) > .collapsible-summary::before {
     font-weight: 600;
 }
 
+.record-entry a {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 182, 18, 0.45);
+    text-underline-offset: 2px;
+}
+
+.record-entry a:hover {
+    color: #ffb612;
+    text-decoration-color: #ffb612;
+}
+
 .record-empty {
     color: rgba(255, 255, 255, 0.7);
     flex: 1;

--- a/styles.css
+++ b/styles.css
@@ -1281,6 +1281,14 @@ details:not([open]) > .collapsible-summary::before {
     flex: 1;
 }
 
+/* The ties card lists every tie (39 and counting) — scroll it instead of
+   letting it stretch the whole grid row. */
+#card-ties .record-list {
+    max-height: 21rem;
+    overflow-y: auto;
+    padding-right: 0.4rem;
+}
+
 .record-share {
     display: flex;
     gap: 0.4rem;

--- a/styles.css
+++ b/styles.css
@@ -591,22 +591,26 @@ details:not([open]) > .collapsible-summary::before {
     scrollbar-color: #ffb612 #203731;
 }
 
-.schedule-grid::-webkit-scrollbar {
+.schedule-grid::-webkit-scrollbar,
+#card-ties .record-list::-webkit-scrollbar {
     width: 8px;
 }
 
-.schedule-grid::-webkit-scrollbar-track {
+.schedule-grid::-webkit-scrollbar-track,
+#card-ties .record-list::-webkit-scrollbar-track {
     background: #203731;
     border-radius: 4px;
 }
 
-.schedule-grid::-webkit-scrollbar-thumb {
+.schedule-grid::-webkit-scrollbar-thumb,
+#card-ties .record-list::-webkit-scrollbar-thumb {
     background: #ffb612;
     border-radius: 4px;
     border: 1px solid #203731;
 }
 
-.schedule-grid::-webkit-scrollbar-thumb:hover {
+.schedule-grid::-webkit-scrollbar-thumb:hover,
+#card-ties .record-list::-webkit-scrollbar-thumb:hover {
     background: #ffd050;
 }
 
@@ -1282,11 +1286,14 @@ details:not([open]) > .collapsible-summary::before {
 }
 
 /* The ties card lists every tie (39 and counting) — scroll it instead of
-   letting it stretch the whole grid row. */
+   letting it stretch the whole grid row. Scrollbar matches .schedule-grid
+   (shared ::-webkit-scrollbar rules above). */
 #card-ties .record-list {
     max-height: 21rem;
     overflow-y: auto;
     padding-right: 0.4rem;
+    scrollbar-width: thin;
+    scrollbar-color: #ffb612 #203731;
 }
 
 .record-share {

--- a/styles.css
+++ b/styles.css
@@ -1149,3 +1149,139 @@ details:not([open]) > .collapsible-summary::before {
         grid-template-columns: 1fr;
     }
 }
+
+/* --- Records & Superlatives page --- */
+
+.records-container {
+    max-width: 900px;
+}
+
+.records-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #ffb612;
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    margin-bottom: 1rem;
+}
+
+.records-back:hover {
+    text-decoration: underline;
+}
+
+.records-title {
+    margin-bottom: 0.25rem;
+}
+
+.records-subtitle {
+    color: rgba(255, 255, 255, 0.75);
+    margin: 0 0 2rem;
+    font-size: 1.05rem;
+}
+
+.records-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+    text-align: left;
+}
+
+.record-card {
+    background: rgba(32, 55, 49, 0.8);
+    border: 2px solid #ffb612;
+    border-radius: 10px;
+    padding: 1.25rem 1.25rem 1rem;
+    display: flex;
+    flex-direction: column;
+    backdrop-filter: blur(10px);
+}
+
+.record-card-focus {
+    box-shadow: 0 0 24px rgba(255, 182, 18, 0.55);
+}
+
+.record-card-title {
+    color: #ffb612;
+    font-size: 1.25rem;
+    margin: 0 0 0.15rem;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.record-note {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.82rem;
+    margin: 0 0 0.9rem;
+}
+
+.record-list {
+    list-style: none;
+    margin: 0 0 1rem;
+    padding: 0;
+    flex: 1;
+}
+
+.record-entry {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.6rem;
+    align-items: baseline;
+    padding: 0.3rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.record-entry:last-child {
+    border-bottom: none;
+}
+
+.record-entry-main {
+    font-weight: bold;
+    font-variant-numeric: tabular-nums;
+    color: white;
+}
+
+.record-entry-sub {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.record-entry-detail {
+    grid-column: 2;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.8rem;
+}
+
+.record-entry-top .record-entry-main {
+    color: #ffb612;
+    font-size: 1.6rem;
+}
+
+.record-entry-top .record-entry-sub {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.record-empty {
+    color: rgba(255, 255, 255, 0.7);
+    flex: 1;
+}
+
+.record-share {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.record-share-btn {
+    padding: 0.35rem 0.6rem;
+    border-radius: 50%;
+    font-size: 1rem;
+}
+
+/* Pill styling comes from .share-btn on the same element. */
+.records-link {
+    margin: 0.75rem auto 0;
+}


### PR DESCRIPTION
## Summary
- New `/records` page of franchise superlatives computed from `data/packers_games.csv`: **best season starts** (13-0 in 2011), **perfect seasons** (1929's 12-0-1), **longest win streaks** (15 straight, 2010-2011), **worst starts**, **most lopsided wins**, **worst losses**, and a scrollable listing of **all 39 ties** (newest first, back to 1921)
- Each superlative is its own shareable card: deep link (`/records/<slug>`), share row (native/X/Bluesky/Facebook/Reddit/copy), server-injected OG meta, and a server-rendered 1200x630 social card at `/og/records/<slug>.png` in the existing per-season card style
- Season years in every table link to their season pages; blowout entries link the game date to the game''s season (a January playoff game belongs to the prior year''s season)
- Computation lives in `records-core.js`, a dependency-free module shared verbatim by the browser page and the web service, so the page and link previews can''t disagree; a "Records & Superlatives" pill on the main page links to it

## Code health along the way
- `lib/seasons.js` and `main.js` now use the shared quote-aware CSV parser (main.js previously had a naive comma-split parser among its three local copies); the CSV is read and parsed once per server process
- New `share-core.js` owns share-intent URLs and copy-with-flash; `main.js` and `records.js` both delegate to it
- Unversioned `.js` is served `no-cache` so ES-module imports can''t pair a fresh versioned entry file with an hour-stale dependency across deploys
- Perfect seasons only count once a season is settled (March 1 of the following year), so mid-season CSV updates can''t crown an unbeaten October team
- `/records.html` gets meta injection like `/index.html`; malformed `/records/*` URLs 404 instead of falling through to the homepage shell

## Testing
- Client verified in a real browser against a static server: data matches the record books, share links/copy flash, deep-link focus + title, season links, ties scroll, main page fully working after the parser consolidation (schedule, photos, shares), zero console errors
- OG card layouts rendered as SVG in-browser and every text element measured for overflow (all fit; Arial is metric-compatible with the bundled Liberation Sans)
- Node-side files parse-checked via browser module loader; `server.js` routes/PNG rendering follow the existing per-season card pattern and get their first live exercise on deploy - worth a quick check of `/records` and `/og/records/overview.png` after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)