### PR TITLE
All-time head-to-head vs every opponent, with rivalry pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ The computation lives in `records-core.js`, a dependency-free module shared verb
 
 ## Head-to-Head
 
-`/vs` lists the Packers' all-time record against every opponent they've ever faced (defunct franchises included — the CSV normalizes relocated teams to their modern names), sorted by meetings played with a filter box. Each opponent gets its own rivalry page at `/vs/<opponent-slug>` (e.g. `/vs/chicago-bears`): overall and playoff record, first/last meeting, current streak, biggest win, share buttons, and a server-rendered social card at `/og/vs/<slug>.png`. Computation lives in `h2h-core.js`, shared by the browser page (`vs.html` + `vs.js`) and the web service (`lib/h2h.js`).
+`/vs` lists the Packers' all-time record against every opponent they've ever faced (defunct franchises included), sorted by meetings played. The table can be filtered by name, venue (home/away), game type (regular season/playoffs) — these recompute the records from the raw game rows, not just hide rows — and restricted to current franchises only. Each opponent gets its own rivalry page at `/vs/<opponent-slug>` (e.g. `/vs/chicago-bears`): overall and playoff record, first/last meeting, current streak, biggest win, share buttons, and a server-rendered social card at `/og/vs/<slug>.png`. Computation lives in `h2h-core.js`, shared by the browser page (`vs.html` + `vs.js`) and the web service (`lib/h2h.js`).
+
+The CSV's pre-1999 rows map franchises to modern names but the 1999+ rows use as-of-game names, so `h2h-core.js` folds relocated-franchise aliases together (St. Louis Rams → Los Angeles Rams, San Diego → Los Angeles Chargers, Oakland → Las Vegas Raiders). The 1950 Baltimore Colts and the 1945–52 Dallas Texans lineage are distinct defunct franchises and stay separate.
+
+The current season's schedule on the main page annotates each game with the all-time head-to-head record against that opponent, linking to the rivalry page.
 
 ## Data Files
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ When the override is active, a small reset link appears in the card header to cl
 
 The computation lives in `records-core.js`, a dependency-free module shared verbatim by the browser page (`records.html` + `records.js`) and the web service (`lib/records.js`), so the page and the link previews can never disagree.
 
+## Head-to-Head
+
+`/vs` lists the Packers' all-time record against every opponent they've ever faced (defunct franchises included — the CSV normalizes relocated teams to their modern names), sorted by meetings played with a filter box. Each opponent gets its own rivalry page at `/vs/<opponent-slug>` (e.g. `/vs/chicago-bears`): overall and playoff record, first/last meeting, current streak, biggest win, share buttons, and a server-rendered social card at `/og/vs/<slug>.png`. Computation lives in `h2h-core.js`, shared by the browser page (`vs.html` + `vs.js`) and the web service (`lib/h2h.js`).
+
 ## Data Files
 
 `data/packers_games.csv` — game-by-game results for every Packers game from 1921 to the present, including opponent, score, location, and playoff/Super Bowl flags. Pre-1999 rows come from the FiveThirtyEight source; 1999–present rows are sourced from nflverse-data.
@@ -112,7 +116,9 @@ server.js            # web service (static serving + meta injection + card route
 lib/cards.js         # SVG -> PNG card generator (seasons + records)
 lib/seasons.js       # per-season record from CSV + live ESPN feed
 lib/records.js       # records/superlatives data + meta for /records routes
+lib/h2h.js           # head-to-head data + meta for /vs routes
 records-core.js      # shared superlative computation (browser + node)
+h2h-core.js          # shared head-to-head computation (browser + node)
 fonts/               # Liberation Sans (SIL OFL 1.1), bundled for deterministic rendering
 render.yaml          # Render Blueprint
 ```

--- a/h2h-core.js
+++ b/h2h-core.js
@@ -5,6 +5,29 @@ import { rec, formatDate } from './records-core.js';
 export const slugifyOpponent = (name) =>
 	name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
+// The CSV's pre-1999 rows (FiveThirtyEight) map franchises to modern names,
+// but the 1999+ rows (nflverse) use as-of-game names, splitting relocated
+// franchises in two. Fold those eras together. (Baltimore Colts and Dallas
+// Texans are NOT aliases — those are distinct defunct franchises.)
+const FRANCHISE_ALIASES = {
+	'St. Louis Rams': 'Los Angeles Rams',
+	'San Diego Chargers': 'Los Angeles Chargers',
+	'Oakland Raiders': 'Las Vegas Raiders',
+};
+export const canonicalOpponent = (name) => FRANCHISE_ALIASES[name] || name;
+
+// The 31 other active NFL franchises, by the canonical names used in the CSV.
+const CURRENT_FRANCHISES = new Set([
+	'Arizona Cardinals', 'Atlanta Falcons', 'Baltimore Ravens', 'Buffalo Bills',
+	'Carolina Panthers', 'Chicago Bears', 'Cincinnati Bengals', 'Cleveland Browns',
+	'Dallas Cowboys', 'Denver Broncos', 'Detroit Lions', 'Houston Texans',
+	'Indianapolis Colts', 'Jacksonville Jaguars', 'Kansas City Chiefs', 'Las Vegas Raiders',
+	'Los Angeles Chargers', 'Los Angeles Rams', 'Miami Dolphins', 'Minnesota Vikings',
+	'New England Patriots', 'New Orleans Saints', 'New York Giants', 'New York Jets',
+	'Philadelphia Eagles', 'Pittsburgh Steelers', 'San Francisco 49ers', 'Seattle Seahawks',
+	'Tampa Bay Buccaneers', 'Tennessee Titans', 'Washington Commanders',
+]);
+
 const RESULTS = new Set(['WIN', 'LOSS', 'TIE']);
 
 // rows: parsed CSV rows. Returns { opponents, bySlug } — opponents sorted by
@@ -18,8 +41,9 @@ export function computeHeadToHead(rows) {
 
 	const byOpp = new Map();
 	for (const g of games) {
-		if (!byOpp.has(g.Opponent)) byOpp.set(g.Opponent, []);
-		byOpp.get(g.Opponent).push(g);
+		const name = canonicalOpponent(g.Opponent);
+		if (!byOpp.has(name)) byOpp.set(name, []);
+		byOpp.get(name).push(g);
 	}
 
 	const info = (g) => ({
@@ -48,6 +72,7 @@ export function computeHeadToHead(rows) {
 		const playoffGames = playoff.WIN + playoff.LOSS + playoff.TIE;
 		return {
 			name, slug: slugifyOpponent(name),
+			current: CURRENT_FRANCHISES.has(name),
 			games: list.length,
 			wins: count.WIN, losses: count.LOSS, ties: count.TIE,
 			record: rec(count.WIN, count.LOSS, count.TIE),

--- a/h2h-core.js
+++ b/h2h-core.js
@@ -1,0 +1,92 @@
+// Shared (browser + node) all-time head-to-head records vs every opponent,
+// computed from data/packers_games.csv. Pure functions only — no fs/fetch/DOM.
+import { rec, formatDate } from './records-core.js';
+
+export const slugifyOpponent = (name) =>
+	name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+const RESULTS = new Set(['WIN', 'LOSS', 'TIE']);
+
+// rows: parsed CSV rows. Returns { opponents, bySlug } — opponents sorted by
+// meetings played (rivals first), then name. All games count (playoffs
+// included); the playoff split is broken out per opponent.
+export function computeHeadToHead(rows) {
+	const games = rows
+		.filter((g) => RESULTS.has(g['Packers Win']))
+		.slice()
+		.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+	const byOpp = new Map();
+	for (const g of games) {
+		if (!byOpp.has(g.Opponent)) byOpp.set(g.Opponent, []);
+		byOpp.get(g.Opponent).push(g);
+	}
+
+	const info = (g) => ({
+		date: g.date, season: parseInt(g.season, 10),
+		result: g['Packers Win'],
+		pf: parseInt(g.packers_score, 10) || 0,
+		pa: parseInt(g.opponent_score, 10) || 0,
+	});
+
+	const opponents = [...byOpp.entries()].map(([name, list]) => {
+		const count = { WIN: 0, LOSS: 0, TIE: 0 };
+		const playoff = { WIN: 0, LOSS: 0, TIE: 0 };
+		let biggestWin = null;
+		for (const g of list) {
+			const r = g['Packers Win'];
+			count[r]++;
+			if (g.regular_season !== '1') playoff[r]++;
+			if (r === 'WIN') {
+				const w = info(g);
+				if (!biggestWin || w.pf - w.pa > biggestWin.pf - biggestWin.pa) biggestWin = w;
+			}
+		}
+		const last = list[list.length - 1];
+		let streak = 1;
+		for (let i = list.length - 2; i >= 0 && list[i]['Packers Win'] === last['Packers Win']; i--) streak++;
+		const playoffGames = playoff.WIN + playoff.LOSS + playoff.TIE;
+		return {
+			name, slug: slugifyOpponent(name),
+			games: list.length,
+			wins: count.WIN, losses: count.LOSS, ties: count.TIE,
+			record: rec(count.WIN, count.LOSS, count.TIE),
+			winPct: (count.WIN + count.TIE / 2) / list.length,
+			playoffGames,
+			playoffRecord: playoffGames ? rec(playoff.WIN, playoff.LOSS, playoff.TIE) : null,
+			first: info(list[0]), last: info(last),
+			streak: { result: last['Packers Win'], count: streak },
+			biggestWin,
+		};
+	}).sort((a, b) => b.games - a.games || (a.name < b.name ? -1 : 1));
+
+	return { opponents, bySlug: new Map(opponents.map((o) => [o.slug, o])) };
+}
+
+// "The Packers have won the last 8 meetings." / single-game fallback.
+export function streakSentence(o) {
+	const { result, count } = o.streak;
+	const verb = result === 'WIN' ? 'won' : result === 'LOSS' ? 'lost' : 'tied';
+	if (count >= 2) return `The Packers have ${verb} the last ${count} meetings.`;
+	const noun = result === 'WIN' ? 'win' : result === 'LOSS' ? 'loss' : 'tie';
+	return `Last meeting: a ${o.last.pf}–${o.last.pa} ${noun} on ${formatDate(o.last.date)}.`;
+}
+
+// Per-opponent copy shared by server OG meta and client share messages.
+// slug 'overview'/unknown -> landing-page copy.
+export function h2hCopy(slug, data) {
+	const o = data.bySlug.get(slug);
+	if (!o) {
+		const top = data.opponents[0];
+		return {
+			title: 'Packers All-Time Head-to-Head',
+			desc: `The Packers' all-time record against all ${data.opponents.length} opponents they've ever faced. Most played: the ${top.name}, ${top.record} in ${top.games} meetings.`,
+		};
+	}
+	return {
+		title: `Packers vs ${o.name} — ${o.record} all-time`,
+		desc: `The Packers are ${o.record} all-time against the ${o.name} in ${meetings(o.games)}. ${streakSentence(o)}`,
+	};
+}
+
+export const meetings = (n) => `${n} meeting${n === 1 ? '' : 's'}`;

--- a/index.html
+++ b/index.html
@@ -53,8 +53,9 @@
 
         <div id="last-undefeated" class="last-undefeated"></div>
 
-        <!-- /records.html works under both server.js (meta-injected, canonical=/records) and static dev servers -->
+        <!-- .html links work under both server.js (meta-injected, clean canonical) and static dev servers -->
         <a href="/records.html" class="share-btn records-link"><i class="mdi mdi-trophy-outline"></i> Records &amp; Superlatives</a>
+        <a href="/vs.html" class="share-btn records-link"><i class="mdi mdi-sword-cross"></i> Head-to-Head</a>
 
         <div class="share-section">
             <button id="share-native" class="share-btn" hidden>

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import { Resvg } from '@resvg/resvg-js';
 import * as OT from 'opentype.js';
 import { formatDate, streakSpan, esc } from '../records-core.js';
+import { meetings } from '../h2h-core.js';
 
 const opentype = OT.default ?? OT;
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -110,20 +111,20 @@ export function renderPng(state) {
 
 // --- Records & Superlatives cards ---
 
-const title = (text) =>
-  `<text x="600" y="120" font-family="${FONT}" font-size="58" font-weight="bold" fill="${GOLD}" text-anchor="middle" letter-spacing="2">${esc(text)}</text>`;
+const title = (text, size = 58) =>
+  `<text x="600" y="120" font-family="${FONT}" font-size="${size}" font-weight="bold" fill="${GOLD}" text-anchor="middle" letter-spacing="2">${esc(text)}</text>`;
 const headline = (text, color = GOLD) =>
   `<text x="600" y="345" font-family="${FONT}" font-size="130" font-weight="bold" fill="${color}" text-anchor="middle">${esc(text)}</text>`;
 
 // Standard records layout: title, season-range subtitle, big #1, context line,
 // then up to two runner-up lines.
-function recordsFrame({ heading, big, bigColor, context, runners, range }) {
+function recordsFrame({ heading, headingSize, big, bigColor, context, runners, range }) {
   const runnerLines = (runners || [])
     .slice(0, 2)
     .map((r, i) => sub(462 + i * 46, r))
     .join('');
   return frame(
-    title(heading)
+    title(heading, headingSize)
     + sub(168, `Green Bay Packers · ${range}`)
     + headline(big, bigColor)
     + line(408, context, WHITE, 34)
@@ -220,4 +221,44 @@ export function buildRecordsSvg(slug, data) {
 
 export function renderRecordsPng(slug, data) {
   return toPng(buildRecordsSvg(slug, data));
+}
+
+// --- Head-to-head cards ---
+
+// slug + data from h2h-core computeHeadToHead(); unknown/'overview' slug gets
+// the landing card.
+export function buildH2hSvg(slug, data) {
+  const o = data.bySlug.get(slug);
+  if (!o) {
+    const [a, b] = data.opponents;
+    return recordsFrame({
+      heading: 'HEAD-TO-HEAD', range: 'all-time',
+      big: String(data.opponents.length),
+      context: 'opponents faced since 1921',
+      runners: [
+        `most played: ${a.name} — ${a.record} in ${a.games} meetings`,
+        `then ${b.name} — ${b.record} in ${b.games}`,
+      ],
+    });
+  }
+  const { result, count } = o.streak;
+  const verb = result === 'WIN' ? 'won' : result === 'LOSS' ? 'lost' : 'tied';
+  const streakLine = count >= 2
+    ? `${verb} the last ${count} meetings`
+    : `last meeting: ${o.last.pf}–${o.last.pa} ${result === 'WIN' ? 'win' : result === 'LOSS' ? 'loss' : 'tie'}, ${formatDate(o.last.date)}`;
+  const bigWinLine = o.biggestWin
+    ? `biggest win: ${o.biggestWin.pf}–${o.biggestWin.pa} (${o.biggestWin.season})`
+    : 'still chasing the first win';
+  const heading = `VS THE ${o.name.toUpperCase()}`;
+  return recordsFrame({
+    heading, headingSize: heading.length > 24 ? 44 : 58,
+    range: 'all-time head-to-head',
+    big: o.record,
+    context: `${meetings(o.games)} · first met ${o.first.season}`,
+    runners: [streakLine, bigWinLine],
+  });
+}
+
+export function renderH2hPng(slug, data) {
+  return toPng(buildH2hSvg(slug, data));
 }

--- a/lib/h2h.js
+++ b/lib/h2h.js
@@ -1,0 +1,16 @@
+// Server-side head-to-head: computed once at startup from the same parsed CSV
+// rows lib/seasons.js loads. Pure computation lives in h2h-core.js (shared
+// with the browser page).
+import { computeHeadToHead, h2hCopy } from '../h2h-core.js';
+import { allGames } from './seasons.js';
+
+export const h2h = computeHeadToHead(allGames);
+
+export function isOpponentSlug(slug) {
+	return h2h.bySlug.has(slug);
+}
+
+// slug undefined/'overview' -> landing-page copy.
+export function h2hMeta(slug) {
+	return h2hCopy(slug || 'overview', h2h);
+}

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
         import { parseGamesCsv } from './records-core.js';
+        import { computeHeadToHead, canonicalOpponent } from './h2h-core.js';
         import { intentUrls, copyText, flashCopied } from './share-core.js';
 
         function buildSeasonMap(games) {
@@ -59,6 +60,8 @@
         				const raw = await gamesRes.text();
         				const games = parseGamesCsv(raw);
         				this.csvBySeason = buildSeasonMap(games);
+        				// name -> all-time head-to-head entry, for schedule annotations
+        				this.h2hByName = new Map(computeHeadToHead(games).opponents.map(o => [o.name, o]));
         				const seasons = Object.keys(this.csvBySeason).map(Number).sort((a, b) => a - b);
         				if (seasons.length) {
         					this.earliestSeason = seasons[0];
@@ -307,9 +310,25 @@ processCsvSeasonData(season) {
  this.updateStreakBanner(csvCompletedGames, season !== this.latestSeason);
 }
 
+// All-time head-to-head note linking to the opponent's rivalry page.
+// Returns null for opponents with no CSV history (shouldn't happen).
+h2hNote(opponentName) {
+  const o = this.h2hByName?.get(canonicalOpponent(opponentName));
+  if (!o) return null;
+  const note = document.createElement('a');
+  note.className = 'game-h2h';
+  note.href = `/vs/${o.slug}`;
+  note.textContent = `All-time: ${o.record}`;
+  note.title = `Packers vs ${o.name} — all-time head-to-head`;
+  return note;
+}
+
 displayCsvSchedule(games, season) {
   const scheduleGrid = document.getElementById('schedule-grid');
   scheduleGrid.innerHTML = '';
+
+  // Head-to-head notes only make sense on the current season's schedule.
+  const showH2h = season === this.latestSeason;
 
         		// Sort by date
   const sorted = [...games].sort((a, b) => new Date(a.date) - new Date(b.date));
@@ -329,11 +348,11 @@ displayCsvSchedule(games, season) {
         scheduleGrid.appendChild(divider);
     }
 
-    scheduleGrid.appendChild(this.createCsvGameItem(g));
+    scheduleGrid.appendChild(this.createCsvGameItem(g, showH2h));
 });
 }
 
-createCsvGameItem(g) {
+createCsvGameItem(g, showH2h = false) {
         		const result = g['Packers Win']; // WIN / LOSS / TIE
         		const opponent = g.Opponent;
         		const location = g.location; // HOME / AWAY / NEUTRAL
@@ -367,6 +386,11 @@ createCsvGameItem(g) {
 
         		gameDetails.appendChild(opponentDiv);
         		gameDetails.appendChild(dateDiv);
+
+        		if (showH2h) {
+        			const h2h = this.h2hNote(opponent);
+        			if (h2h) gameDetails.appendChild(h2h);
+        		}
 
         		if (isSuperBowl) {
         			const sbLabel = document.createElement('div');
@@ -836,6 +860,14 @@ if (isLive || isInProgress) {
 
 gameDetails.appendChild(opponentDiv);
 gameDetails.appendChild(dateDiv);
+
+// H2H notes only on the current season's schedule (offseason included —
+// displaySchedule's isPastSeason arg also covers "don't autoscroll", so
+// key off the season instead).
+if (this.currentSeason === this.latestSeason) {
+ const h2h = this.h2hNote(opponent);
+ if (h2h) gameDetails.appendChild(h2h);
+}
 
 if (isLive || isInProgress) {
  const statusDiv = document.createElement('div');

--- a/records-core.js
+++ b/records-core.js
@@ -31,7 +31,7 @@ export function formatDate(iso) {
 	return `${MONTHS[m - 1]} ${d}, ${y}`;
 }
 
-const rec = (w, l, t) => (t > 0 ? `${w}–${l}–${t}` : `${w}–${l}`);
+export const rec = (w, l, t) => (t > 0 ? `${w}–${l}–${t}` : `${w}–${l}`);
 
 export const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 

--- a/records.js
+++ b/records.js
@@ -1,7 +1,7 @@
 // Records & Superlatives page: computes superlatives from the games CSV
 // (records-core.js, shared with the server) and renders one shareable card each.
 import { parseGamesCsv, computeSuperlatives, recordsCopy, formatDate, RECORD_SLUGS, esc } from './records-core.js';
-import { intentUrls, copyText, flashCopied } from './share-core.js';
+import { shareButtonsHtml, wireShareRow } from './share-core.js';
 
 const yearLink = (yr) => `<a href="/${yr}">${yr}</a>`;
 const gameFlag = (g) => (g.superbowl ? ' · Super Bowl' : g.playoff ? ' · Playoffs' : '');
@@ -69,17 +69,7 @@ function entryHtml(e, i) {
 }
 
 function shareRowHtml(slug) {
-	const native = !!navigator.share;
-	const alts = native ? '' : `
-		<a class="share-btn record-share-btn" data-share="x" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on X"><i class="mdi mdi-twitter"></i></a>
-		<a class="share-btn record-share-btn" data-share="bsky" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Bluesky"><i class="mdi mdi-butterfly"></i></a>
-		<a class="share-btn record-share-btn" data-share="fb" href="#" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook"><i class="mdi mdi-facebook"></i></a>
-		<a class="share-btn record-share-btn" data-share="reddit" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Reddit"><i class="mdi mdi-reddit"></i></a>`;
-	return `<div class="record-share" data-slug="${slug}">
-		${native ? '<button class="share-btn record-share-btn" data-share="native" aria-label="Share"><i class="mdi mdi-share-variant"></i></button>' : ''}
-		${alts}
-		<button class="share-btn record-share-btn" data-share="copy" aria-label="Copy link"><i class="mdi mdi-clipboard-outline"></i></button>
-	</div>`;
+	return `<div class="record-share" data-slug="${slug}">${shareButtonsHtml('share-btn record-share-btn')}</div>`;
 }
 
 function cardHtml(card, data) {
@@ -98,28 +88,7 @@ function cardHtml(card, data) {
 function wireShares(grid, data) {
 	grid.querySelectorAll('.record-share').forEach((row) => {
 		const slug = row.dataset.slug;
-		const url = `${window.location.origin}/records/${slug}`;
-		const message = recordsCopy(slug, data).desc;
-		const links = intentUrls(message, url);
-		row.querySelectorAll('[data-share]').forEach((btn) => {
-			switch (btn.dataset.share) {
-				case 'x': btn.href = links.x; break;
-				case 'bsky': btn.href = links.bsky; break;
-				case 'fb': btn.href = links.fb; break;
-				case 'reddit': btn.href = links.reddit; break;
-				case 'native':
-					btn.addEventListener('click', async () => {
-						try { await navigator.share({ text: message, url }); } catch { /* user cancelled */ }
-					});
-					break;
-				case 'copy':
-					btn.addEventListener('click', () => {
-						flashCopied(btn, '<i class="mdi mdi-check"></i>');
-						copyText(`${message}\n\n${url}`);
-					});
-					break;
-			}
-		});
+		wireShareRow(row, recordsCopy(slug, data).desc, `${window.location.origin}/records/${slug}`);
 	});
 }
 

--- a/server.js
+++ b/server.js
@@ -8,9 +8,10 @@ import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, extname } from 'node:path';
-import { renderPng, renderRecordsPng } from './lib/cards.js';
+import { renderPng, renderRecordsPng, renderH2hPng } from './lib/cards.js';
 import { getSeasonState, defaultSeason } from './lib/seasons.js';
 import { records, recordsMeta, isRecordSlug } from './lib/records.js';
+import { h2h, h2hMeta, isOpponentSlug } from './lib/h2h.js';
 import { esc } from './records-core.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -48,6 +49,7 @@ function loadShell(file, assets) {
 }
 const INDEX_VERSIONED = loadShell('index.html', ['main.js', 'styles.css']);
 const RECORDS_VERSIONED = loadShell('records.html', ['records.js', 'styles.css']);
+const VS_VERSIONED = loadShell('vs.html', ['vs.js', 'styles.css']);
 
 const MIME = {
   '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
@@ -136,14 +138,23 @@ function serveRecordsHtml(req, res, slug) {
   sendPage(res, RECORDS_VERSIONED, { title, desc, img, canonical });
 }
 
-// Records data is fixed for the lifetime of the process (CSV is read at
+// /vs and /vs/<opponent>: same shell, per-opponent meta + social card.
+function serveVsHtml(req, res, slug) {
+  const origin = originOf(req);
+  const { title, desc } = h2hMeta(slug);
+  const canonical = slug ? `${origin}/vs/${slug}` : `${origin}/vs`;
+  const img = `${origin}/og/vs/${slug || 'overview'}.png`;
+  sendPage(res, VS_VERSIONED, { title, desc, img, canonical });
+}
+
+// Records/h2h data is fixed for the lifetime of the process (CSV is read at
 // startup; updates arrive via redeploy), so render each card at most once.
-const recordsImgCache = new Map(); // slug -> buf
-function serveRecordsImage(res, slug) {
-  let buf = recordsImgCache.get(slug);
+const staticImgCache = new Map(); // cache key -> buf
+function serveCachedPng(res, key, render) {
+  let buf = staticImgCache.get(key);
   if (!buf) {
-    buf = renderRecordsPng(slug, records);
-    recordsImgCache.set(slug, buf);
+    buf = render();
+    staticImgCache.set(key, buf);
   }
   res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=3600' });
   res.end(buf);
@@ -208,7 +219,13 @@ const server = http.createServer(async (req, res) => {
     const ogRec = pathname.match(/^\/og\/records\/([a-z-]+)\.png$/);
     if (ogRec) {
       if (ogRec[1] !== 'overview' && !isRecordSlug(ogRec[1])) return notFound(res);
-      return serveRecordsImage(res, ogRec[1]);
+      return serveCachedPng(res, `records:${ogRec[1]}`, () => renderRecordsPng(ogRec[1], records));
+    }
+
+    const ogVs = pathname.match(/^\/og\/vs\/([a-z0-9-]+)\.png$/);
+    if (ogVs) {
+      if (ogVs[1] !== 'overview' && !isOpponentSlug(ogVs[1])) return notFound(res);
+      return serveCachedPng(res, `vs:${ogVs[1]}`, () => renderH2hPng(ogVs[1], h2h));
     }
 
     const img = pathname.match(/^\/og\/(\d{4})\.png$/);
@@ -236,6 +253,14 @@ const server = http.createServer(async (req, res) => {
       const slug = pathname.slice('/records/'.length).replace(/\/$/, '');
       if (!isRecordSlug(slug)) return notFound(res);
       return serveRecordsHtml(req, res, slug);
+    }
+
+    if (pathname === '/vs' || pathname === '/vs/' || pathname === '/vs.html')
+      return serveVsHtml(req, res, undefined);
+    if (pathname.startsWith('/vs/')) {
+      const slug = pathname.slice('/vs/'.length).replace(/\/$/, '');
+      if (!isOpponentSlug(slug)) return notFound(res);
+      return serveVsHtml(req, res, slug);
     }
 
     return await serveStatic(req, res, pathname);

--- a/share-core.js
+++ b/share-core.js
@@ -11,6 +11,45 @@ export function intentUrls(message, url) {
 	};
 }
 
+// Icon-only share buttons for a compact per-card share row: native share when
+// supported, otherwise the per-platform intent links, plus copy. Pair with
+// wireShareRow() after inserting into the DOM.
+export function shareButtonsHtml(btnClass) {
+	const native = !!navigator.share;
+	const alts = native ? '' : `
+		<a class="${btnClass}" data-share="x" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on X"><i class="mdi mdi-twitter"></i></a>
+		<a class="${btnClass}" data-share="bsky" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Bluesky"><i class="mdi mdi-butterfly"></i></a>
+		<a class="${btnClass}" data-share="fb" href="#" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook"><i class="mdi mdi-facebook"></i></a>
+		<a class="${btnClass}" data-share="reddit" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Reddit"><i class="mdi mdi-reddit"></i></a>`;
+	return `${native ? `<button class="${btnClass}" data-share="native" aria-label="Share"><i class="mdi mdi-share-variant"></i></button>` : ''}
+		${alts}
+		<button class="${btnClass}" data-share="copy" aria-label="Copy link"><i class="mdi mdi-clipboard-outline"></i></button>`;
+}
+
+// Wire the [data-share] buttons inside `row` to share `message` + `url`.
+export function wireShareRow(row, message, url) {
+	const links = intentUrls(message, url);
+	row.querySelectorAll('[data-share]').forEach((btn) => {
+		switch (btn.dataset.share) {
+			case 'x': btn.href = links.x; break;
+			case 'bsky': btn.href = links.bsky; break;
+			case 'fb': btn.href = links.fb; break;
+			case 'reddit': btn.href = links.reddit; break;
+			case 'native':
+				btn.addEventListener('click', async () => {
+					try { await navigator.share({ text: message, url }); } catch { /* user cancelled */ }
+				});
+				break;
+			case 'copy':
+				btn.addEventListener('click', () => {
+					flashCopied(btn, '<i class="mdi mdi-check"></i>');
+					copyText(`${message}\n\n${url}`);
+				});
+				break;
+		}
+	});
+}
+
 // Flash a button into its "copied" state for 2s, restoring its original
 // content afterwards. Safe to call repeatedly (re-clicks reset the timer).
 const flashState = new WeakMap(); // btn -> { original, timer }

--- a/styles.css
+++ b/styles.css
@@ -670,6 +670,20 @@ details:not([open]) > .collapsible-summary::before {
     color: #ffb612;
 }
 
+/* All-time head-to-head note on current-season schedule items */
+.game-h2h {
+    display: block;
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.65);
+    text-decoration: none;
+    margin-top: 0.15rem;
+}
+
+.game-h2h:hover {
+    color: #ffb612;
+    text-decoration: underline;
+}
+
 .game-network {
     opacity: 0.7;
     font-style: italic;
@@ -1361,13 +1375,57 @@ details:not([open]) > .collapsible-summary::before {
 }
 
 .h2h-controls {
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.35rem;
     text-align: left;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.h2h-select {
+    padding: 0.5rem 0.9rem;
+    background: rgba(32, 55, 49, 0.8);
+    border: 1.5px solid rgba(255, 182, 18, 0.5);
+    border-radius: 20px;
+    color: white;
+    font-size: 0.9rem;
+}
+
+.h2h-select:focus {
+    outline: none;
+    border-color: #ffb612;
+}
+
+.h2h-select option {
+    background: #203731;
+}
+
+.h2h-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.9rem;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.h2h-check input {
+    accent-color: #ffb612;
+}
+
+.h2h-count {
+    text-align: left;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.85rem;
+    margin: 0 0 0.75rem;
+    min-height: 1em;
 }
 
 .h2h-filter {
     width: 100%;
-    max-width: 20rem;
+    max-width: 14rem;
     box-sizing: border-box;
     padding: 0.5rem 0.9rem;
     background: rgba(32, 55, 49, 0.8);

--- a/styles.css
+++ b/styles.css
@@ -1499,3 +1499,24 @@ details:not([open]) > .collapsible-summary::before {
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
 }
+
+@media (max-width: 600px) {
+    /* Tighten the table so it fits a phone viewport instead of overflowing
+       into a horizontal scroll (opponent names wrap; numbers stay nowrap). */
+    .h2h-table th,
+    .h2h-table td {
+        padding: 0.4rem 0.45rem;
+    }
+
+    .h2h-table td {
+        font-size: 0.9rem;
+    }
+
+    .h2h-table th {
+        font-size: 0.72rem;
+    }
+
+    .h2h-filter {
+        max-width: 100%;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1310,5 +1310,129 @@ details:not([open]) > .collapsible-summary::before {
 
 /* Pill styling comes from .share-btn on the same element. */
 .records-link {
-    margin: 0.75rem auto 0;
+    margin: 0.75rem 0.25rem 0;
+}
+
+/* --- Head-to-Head page --- */
+
+.h2h-focus-card {
+    margin-bottom: 1.5rem;
+    text-align: left;
+}
+
+.h2h-record {
+    color: #ffb612;
+    font-size: 2.6rem;
+    font-weight: bold;
+    font-variant-numeric: tabular-nums;
+    margin: 0.1rem 0 0.35rem;
+}
+
+.h2h-stats {
+    margin-bottom: 1rem;
+}
+
+.h2h-stat {
+    display: grid;
+    grid-template-columns: 8.5rem 1fr;
+    column-gap: 0.6rem;
+    padding: 0.3rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.h2h-stat:last-child {
+    border-bottom: none;
+}
+
+.h2h-stat-label {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.h2h-stat a {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 182, 18, 0.45);
+    text-underline-offset: 2px;
+}
+
+.h2h-stat a:hover {
+    color: #ffb612;
+    text-decoration-color: #ffb612;
+}
+
+.h2h-controls {
+    margin-bottom: 0.75rem;
+    text-align: left;
+}
+
+.h2h-filter {
+    width: 100%;
+    max-width: 20rem;
+    box-sizing: border-box;
+    padding: 0.5rem 0.9rem;
+    background: rgba(32, 55, 49, 0.8);
+    border: 1.5px solid rgba(255, 182, 18, 0.5);
+    border-radius: 20px;
+    color: white;
+    font-size: 0.95rem;
+}
+
+.h2h-filter::placeholder {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.h2h-filter:focus {
+    outline: none;
+    border-color: #ffb612;
+}
+
+.h2h-table-wrap {
+    overflow-x: auto;
+}
+
+.h2h-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: rgba(32, 55, 49, 0.8);
+    border: 2px solid #ffb612;
+    border-radius: 10px;
+    overflow: hidden;
+    text-align: left;
+}
+
+.h2h-table th,
+.h2h-table td {
+    padding: 0.45rem 0.9rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.h2h-table th {
+    color: #ffb612;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.h2h-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.h2h-table tbody tr:hover {
+    background: rgba(255, 182, 18, 0.08);
+}
+
+.h2h-table td a {
+    color: white;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.h2h-table td a:hover {
+    color: #ffb612;
+}
+
+.h2h-num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
 }

--- a/styles.css
+++ b/styles.css
@@ -1376,11 +1376,16 @@ details:not([open]) > .collapsible-summary::before {
 
 .h2h-controls {
     margin-bottom: 0.35rem;
-    text-align: left;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
     align-items: center;
+    justify-content: center;
+    /* The centered page layout sizes the container to its widest child (the
+       table); span it so the controls center as one row instead of
+       shrink-wrapping into a ragged stack. */
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .h2h-select {
@@ -1416,7 +1421,7 @@ details:not([open]) > .collapsible-summary::before {
 }
 
 .h2h-count {
-    text-align: left;
+    text-align: center;
     color: rgba(255, 255, 255, 0.6);
     font-size: 0.85rem;
     margin: 0 0 0.75rem;
@@ -1425,7 +1430,7 @@ details:not([open]) > .collapsible-summary::before {
 
 .h2h-filter {
     width: 100%;
-    max-width: 14rem;
+    max-width: 12rem;
     box-sizing: border-box;
     padding: 0.5rem 0.9rem;
     background: rgba(32, 55, 49, 0.8);

--- a/vs.html
+++ b/vs.html
@@ -21,7 +21,19 @@
         <div id="h2h-focus"></div>
         <div class="h2h-controls">
             <input id="h2h-filter" class="h2h-filter" type="search" placeholder="Filter opponents..." aria-label="Filter opponents">
+            <select id="h2h-venue" class="h2h-select" aria-label="Venue">
+                <option value="all">All venues</option>
+                <option value="HOME">Home</option>
+                <option value="AWAY">Away</option>
+            </select>
+            <select id="h2h-type" class="h2h-select" aria-label="Game type">
+                <option value="all">All games</option>
+                <option value="regular">Regular season</option>
+                <option value="playoffs">Playoffs</option>
+            </select>
+            <label class="h2h-check"><input type="checkbox" id="h2h-current"> Current franchises only</label>
         </div>
+        <p id="h2h-count" class="h2h-count"></p>
         <div id="h2h-table-wrap" class="h2h-table-wrap">
             <div class="loading">Loading opponents...</div>
         </div>

--- a/vs.html
+++ b/vs.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Packers All-Time Head-to-Head</title>
+    <meta name="description" content="The Green Bay Packers' all-time record against every opponent they've ever faced.">
+    <meta property="og:title" content="Packers All-Time Head-to-Head">
+    <meta property="og:description" content="The Green Bay Packers' all-time record against every opponent they've ever faced.">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
+    <!-- Absolute asset paths: this shell is also served at /vs/<opponent>, where relative paths would break. -->
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="container records-container">
+        <a href="/" class="records-back"><i class="mdi mdi-arrow-left"></i> Are the Packers Undefeated?</a>
+        <h1 class="records-title">Head-to-Head</h1>
+        <p id="h2h-subtitle" class="records-subtitle"></p>
+        <div id="h2h-focus"></div>
+        <div class="h2h-controls">
+            <input id="h2h-filter" class="h2h-filter" type="search" placeholder="Filter opponents..." aria-label="Filter opponents">
+        </div>
+        <div id="h2h-table-wrap" class="h2h-table-wrap">
+            <div class="loading">Loading opponents...</div>
+        </div>
+    </div>
+
+    <footer class="site-footer">
+        <a href="https://github.com/rptetzloff/AreThePackersUndefeated" target="_blank" rel="noopener noreferrer" class="github-link">
+            <i class="mdi mdi-github"></i>
+            View on GitHub
+        </a>
+    </footer>
+
+    <script src="/vs.js" type="module"></script>
+</body>
+</html>

--- a/vs.js
+++ b/vs.js
@@ -70,6 +70,22 @@ async function init() {
 		};
 		const countEl = document.getElementById('h2h-count');
 
+		// Filter settings persist across sessions (like the emoji toggle and
+		// section states); the typed name query is transient.
+		try {
+			const stored = JSON.parse(localStorage.getItem('h2hFilters') || '{}');
+			if ([...controls.venue.options].some((o) => o.value === stored.venue)) controls.venue.value = stored.venue;
+			if ([...controls.type.options].some((o) => o.value === stored.type)) controls.type.value = stored.type;
+			controls.current.checked = stored.current === true;
+		} catch { /* corrupt storage — keep defaults */ }
+		const saveFilters = () => {
+			localStorage.setItem('h2hFilters', JSON.stringify({
+				venue: controls.venue.value,
+				type: controls.type.value,
+				current: controls.current.checked,
+			}));
+		};
+
 		const renderTable = () => {
 			const venue = controls.venue.value;
 			const type = controls.type.value;
@@ -88,9 +104,9 @@ async function init() {
 			countEl.textContent = filtered ? `${opponents.length} of ${allTime.opponents.length} opponents` : '';
 		};
 		controls.q.addEventListener('input', renderTable);
-		controls.venue.addEventListener('change', renderTable);
-		controls.type.addEventListener('change', renderTable);
-		controls.current.addEventListener('change', renderTable);
+		for (const el of [controls.venue, controls.type, controls.current]) {
+			el.addEventListener('change', () => { saveFilters(); renderTable(); });
+		}
 		renderTable();
 
 		const slug = requestedSlug(allTime);

--- a/vs.js
+++ b/vs.js
@@ -31,7 +31,7 @@ function focusCardHtml(o) {
 
 function tableHtml(opponents) {
 	const rows = opponents.map((o) => `
-		<tr data-name="${esc(o.name.toLowerCase())}">
+		<tr>
 			<td><a href="/vs/${o.slug}">${esc(o.name)}</a></td>
 			<td class="h2h-num">${esc(o.record)}</td>
 			<td class="h2h-num">${o.games}</td>
@@ -55,28 +55,53 @@ async function init() {
 	try {
 		const res = await fetch('/data/packers_games.csv');
 		if (!res.ok) throw new Error(`CSV fetch failed: ${res.status}`);
-		const data = computeHeadToHead(parseGamesCsv(await res.text()));
+		const rows = parseGamesCsv(await res.text());
+		// The focus card and share copy always use the full all-time data;
+		// the venue/type filters recompute a fresh table from the raw rows.
+		const allTime = computeHeadToHead(rows);
 		document.getElementById('h2h-subtitle').textContent =
-			`Green Bay Packers · all-time vs ${data.opponents.length} opponents`;
-		wrap.innerHTML = tableHtml(data.opponents);
+			`Green Bay Packers · all-time vs ${allTime.opponents.length} opponents`;
 
-		const filter = document.getElementById('h2h-filter');
-		filter.addEventListener('input', () => {
-			const q = filter.value.trim().toLowerCase();
-			wrap.querySelectorAll('tbody tr').forEach((tr) => {
-				tr.hidden = q !== '' && !tr.dataset.name.includes(q);
-			});
-		});
+		const controls = {
+			q: document.getElementById('h2h-filter'),
+			venue: document.getElementById('h2h-venue'),
+			type: document.getElementById('h2h-type'),
+			current: document.getElementById('h2h-current'),
+		};
+		const countEl = document.getElementById('h2h-count');
 
-		const slug = requestedSlug(data);
+		const renderTable = () => {
+			const venue = controls.venue.value;
+			const type = controls.type.value;
+			const subset = venue === 'all' && type === 'all' ? rows : rows.filter((g) =>
+				(venue === 'all' || g.location === venue)
+				&& (type === 'all' || (type === 'regular' ? g.regular_season === '1' : g.regular_season !== '1')));
+			const data = venue === 'all' && type === 'all' ? allTime : computeHeadToHead(subset);
+			const q = controls.q.value.trim().toLowerCase();
+			const opponents = data.opponents.filter((o) =>
+				(!controls.current.checked || o.current)
+				&& (q === '' || o.name.toLowerCase().includes(q)));
+			wrap.innerHTML = opponents.length
+				? tableHtml(opponents)
+				: '<p class="record-empty">No opponents match those filters.</p>';
+			const filtered = venue !== 'all' || type !== 'all' || controls.current.checked || q !== '';
+			countEl.textContent = filtered ? `${opponents.length} of ${allTime.opponents.length} opponents` : '';
+		};
+		controls.q.addEventListener('input', renderTable);
+		controls.venue.addEventListener('change', renderTable);
+		controls.type.addEventListener('change', renderTable);
+		controls.current.addEventListener('change', renderTable);
+		renderTable();
+
+		const slug = requestedSlug(allTime);
 		if (slug) {
-			const o = data.bySlug.get(slug);
-			document.title = h2hCopy(slug, data).title;
+			const o = allTime.bySlug.get(slug);
+			document.title = h2hCopy(slug, allTime).title;
 			const focus = document.getElementById('h2h-focus');
 			focus.innerHTML = focusCardHtml(o);
 			wireShareRow(
 				focus.querySelector('.record-share'),
-				h2hCopy(slug, data).desc,
+				h2hCopy(slug, allTime).desc,
 				`${window.location.origin}/vs/${slug}`,
 			);
 		}

--- a/vs.js
+++ b/vs.js
@@ -1,0 +1,89 @@
+// Head-to-Head page: all-time record vs every opponent (h2h-core.js, shared
+// with the server), with a filterable table and a shareable focus card per
+// opponent at /vs/<slug>.
+import { parseGamesCsv, formatDate, esc } from './records-core.js';
+import { computeHeadToHead, h2hCopy, streakSentence } from './h2h-core.js';
+import { shareButtonsHtml, wireShareRow } from './share-core.js';
+
+// Standard sports-page winning percentage: ties count half. ".622" / "1.000".
+const pct = (p) => (p >= 1 ? '1.000' : p.toFixed(3).replace(/^0/, ''));
+
+const resultLetter = { WIN: 'W', LOSS: 'L', TIE: 'T' };
+const meeting = (m) =>
+	`${resultLetter[m.result]} ${m.pf}–${m.pa} · <a href="/${m.season}">${esc(formatDate(m.date))}</a>`;
+
+function focusCardHtml(o) {
+	const stats = [
+		`<span class="h2h-stat-label">Meetings</span><span>${o.games}${o.playoffGames ? ` (${o.playoffGames} playoff)` : ''}</span>`,
+		`<span class="h2h-stat-label">First meeting</span><span>${meeting(o.first)}</span>`,
+		`<span class="h2h-stat-label">Last meeting</span><span>${meeting(o.last)}</span>`,
+		o.playoffRecord ? `<span class="h2h-stat-label">Playoffs</span><span>${esc(o.playoffRecord)}</span>` : null,
+		o.biggestWin ? `<span class="h2h-stat-label">Biggest win</span><span>${o.biggestWin.pf}–${o.biggestWin.pa} · <a href="/${o.biggestWin.season}">${o.biggestWin.season}</a></span>` : null,
+	].filter(Boolean);
+	return `<section class="record-card record-card-focus h2h-focus-card">
+		<h2 class="record-card-title"><i class="mdi mdi-sword-cross"></i> vs ${esc(o.name)}</h2>
+		<div class="h2h-record">${esc(o.record)}</div>
+		<p class="record-note">${esc(streakSentence(o))}</p>
+		<div class="h2h-stats">${stats.map((s) => `<div class="h2h-stat">${s}</div>`).join('')}</div>
+		<div class="record-share">${shareButtonsHtml('share-btn record-share-btn')}</div>
+	</section>`;
+}
+
+function tableHtml(opponents) {
+	const rows = opponents.map((o) => `
+		<tr data-name="${esc(o.name.toLowerCase())}">
+			<td><a href="/vs/${o.slug}">${esc(o.name)}</a></td>
+			<td class="h2h-num">${esc(o.record)}</td>
+			<td class="h2h-num">${o.games}</td>
+			<td class="h2h-num">${pct(o.winPct)}</td>
+		</tr>`).join('');
+	return `<table class="h2h-table">
+		<thead><tr><th>Opponent</th><th class="h2h-num">Record</th><th class="h2h-num">Games</th><th class="h2h-num">Win %</th></tr></thead>
+		<tbody>${rows}</tbody>
+	</table>`;
+}
+
+// /vs/<slug> deep link (or ?vs=<slug> when served statically in dev).
+function requestedSlug(data) {
+	const m = window.location.pathname.match(/\/vs\/([a-z0-9-]+)\/?$/);
+	const slug = m ? m[1] : new URLSearchParams(window.location.search).get('vs');
+	return data.bySlug.has(slug) ? slug : null;
+}
+
+async function init() {
+	const wrap = document.getElementById('h2h-table-wrap');
+	try {
+		const res = await fetch('/data/packers_games.csv');
+		if (!res.ok) throw new Error(`CSV fetch failed: ${res.status}`);
+		const data = computeHeadToHead(parseGamesCsv(await res.text()));
+		document.getElementById('h2h-subtitle').textContent =
+			`Green Bay Packers · all-time vs ${data.opponents.length} opponents`;
+		wrap.innerHTML = tableHtml(data.opponents);
+
+		const filter = document.getElementById('h2h-filter');
+		filter.addEventListener('input', () => {
+			const q = filter.value.trim().toLowerCase();
+			wrap.querySelectorAll('tbody tr').forEach((tr) => {
+				tr.hidden = q !== '' && !tr.dataset.name.includes(q);
+			});
+		});
+
+		const slug = requestedSlug(data);
+		if (slug) {
+			const o = data.bySlug.get(slug);
+			document.title = h2hCopy(slug, data).title;
+			const focus = document.getElementById('h2h-focus');
+			focus.innerHTML = focusCardHtml(o);
+			wireShareRow(
+				focus.querySelector('.record-share'),
+				h2hCopy(slug, data).desc,
+				`${window.location.origin}/vs/${slug}`,
+			);
+		}
+	} catch (e) {
+		wrap.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
+		console.error(e);
+	}
+}
+
+init();


### PR DESCRIPTION
## Summary
- **`/vs`** — the Packers'' all-time record against all 58 opponents they''ve ever faced (defunct 1920s franchises included), sorted by meetings played, with record / games / win % columns
- **Filters that recompute, not just hide**: venue (home/away) and game type (regular season/playoffs) rebuild the records from the raw game rows — so "home record vs the Bears" is a real split (54-43-5 in 102) — plus a name search and a current-franchises-only toggle with a shown-count line. Filter settings persist in localStorage like the site''s other settings
- **`/vs/<slug>` rivalry pages** (e.g. `/vs/chicago-bears`): big all-time record, streak line, meetings with playoff split, first/last meeting, playoff record, biggest win — every date linked to its season page (a January playoff game links to the prior year''s season) — with share buttons and a server-rendered social card at `/og/vs/<slug>.png` whose heading scales down for long franchise names
- **Schedule integration**: every game on the current season''s schedule (offseason included) shows the all-time head-to-head record vs that opponent, linking to the rivalry page; past seasons are unannotated

## Data correctness
- The CSV''s pre-1999 rows use modern franchise names but 1999+ rows use as-of-game names, silently splitting the Rams, Chargers, and Raiders into two opponents each. `h2h-core.js` folds those aliases (Rams: 51-47-2 in 100 meetings, not two partial records). The 1950 Baltimore Colts and the 1945-52 Dallas Texans lineage are genuinely distinct defunct franchises and stay separate

## Architecture
- `h2h-core.js` is a dependency-free module shared verbatim by the browser page (`vs.html` + `vs.js`) and the web service (`lib/h2h.js`), computed from the same parsed rows as everything else — page and link previews can''t disagree
- Share-row markup/wiring moved into `share-core.js` (used by records and head-to-head pages); the records OG image caches collapsed into one helper

## Testing
- Verified in a real browser against a static server: table records match the CSV (Bears 109-98-6/213), filters recompute correctly (playoffs shows 49ers 4-6 in 10 as most-met playoff rival; current-franchises = exactly 31), persistence survives reload, rivalry cards + share wiring, schedule notes on all 20 games of ESPN''s 2026 schedule with correct records and links, and no notes on past seasons
- Mobile: verified at 375px (no horizontal overflow; long names wrap); filter row centers as one line on desktop and wraps centered on phones
- OG card layouts rendered as SVG in-browser and measured for text overflow, including the longest franchise name; node-side files parse-checked. As with the records PR, `/vs` and `/og/vs/overview.png` get their first live exercise on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)