### PR TITLE
Add a site title that changes tense for past seasons

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 </head>
 <body>
     <div class="container">
+        <h1 id="site-title" class="site-title">Are the Packers Undefeated?</h1>
         <div id="answer" class="answer loading">Loading...</div>
         <div id="record" class="record"></div>
         <details id="streak-details" class="collapsible-section" open>

--- a/main.js
+++ b/main.js
@@ -138,7 +138,15 @@
          });
       }
 
+      updateSiteTitle() {
+          const el = document.getElementById('site-title');
+          if (!el) return;
+          const past = this.currentSeason && this.latestSeason && this.currentSeason < this.latestSeason;
+          el.textContent = `${past ? 'Were' : 'Are'} the Packers Undefeated?`;
+      }
+
       updateSeasonSelector() {
+          this.updateSiteTitle();
           const label = document.getElementById('season-label');
           const prevBtn = document.getElementById('season-prev');
           const nextBtn = document.getElementById('season-next');

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,10 @@ h1 {
     color: #ffb612;
 }
 
+.site-title {
+    margin-bottom: 0;
+}
+
 .answer {
     font-size: 4rem;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- Adds a visible page title above the answer: **"Are the Packers Undefeated?"** on the current season, **"Were the Packers Undefeated?"** when browsing any past season
- Updates alongside the season selector, so both the CSV and ESPN data paths get the right tense; existing `h1` styles handle desktop/mobile sizing

## Testing
- Verified in a browser: current season shows "Are", stepping to the previous season and jumping to 1921 both show "Were", returning to the latest season restores "Are"

🤖 Generated with [Claude Code](https://claude.com/claude-code)