### PR TITLE
Franchise history chart, head coaches, and site-wide fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The CSV's pre-1999 rows map franchises to modern names but the 1999+ rows use as
 
 The current season's schedule on the main page annotates each game with the all-time head-to-head record against that opponent, linking to the rivalry page.
 
+## Franchise History Chart
+
+`/history` charts every season since 1921 as one line — win percentage by default (ties count half; early seasons were ~10 games and modern ones 17, so win% reads honestly across eras), with a persisted toggle to raw wins. Championship seasons get gold dots (the 1929–31 standings titles are hardcoded; every later title is "won the season's final playoff game"), perfect seasons get a white ring, coaching-era bands (Lambeau, Lombardi, Holmgren, McCarthy, LaFleur) sit behind the line, hovering shows the record, and clicking a season opens its page. A compact sparkline of the same chart sits under the answer on the main page (the viewed season marked in white) and links to `/history`.
+
+The chart is built by `history-chart.js`, a pure SVG-string module shared by the page (`history.js`), the homepage sparkline (`main.js`), and the server-rendered social card at `/og/history.png` — all three render identical geometry from `computeSeasonHistory()` in `records-core.js`.
+
 ## Data Files
 
 `data/packers_games.csv` — game-by-game results for every Packers game from 1921 to the present, including opponent, score, location, and playoff/Super Bowl flags. Pre-1999 rows come from the FiveThirtyEight source; 1999–present rows are sourced from nflverse-data.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ The chart is built by `history-chart.js`, a pure SVG-string module shared by the
 
 ## Head Coaches
 
-`/coaches` lists every Packers head coach in tenure order with regular-season record, win %, playoff record, and championships. Tenures live in `data/packers_coaches.csv` as from/to **dates**, not seasons, so mid-season changes split correctly (Ronzani → Devore/McLean with two games left in 1953; McCarthy → Philbin after week 13 of 2018) — every game is assigned to a coach by date. Championships count for the coach who coached that champion season's final game. Computation lives in `coaches-core.js`, shared by the browser page (`coaches.html` + `coaches.js`) and the web service (`lib/coaches.js`); the social card is at `/og/coaches.png`.
+`/coaches` lists every Packers head coach in tenure order with photo, regular-season record, win %, playoff record, and championships. Tenures live in `data/packers_coaches.csv` as from/to **dates**, not seasons, so mid-season changes split correctly (Ronzani → Devore/McLean with two games left in 1953; McCarthy → Philbin after week 13 of 2018) — every game is assigned to a coach by date. Interim stints are marked with an asterisk and can be excluded via a persisted toggle. Championships count for the coach who coached that champion season's final game. Computation lives in `coaches-core.js`, shared by the browser page (`coaches.html` + `coaches.js`) and the web service (`lib/coaches.js`); the social card is at `/og/coaches.png`.
+
+Coach photos come from Wikimedia Commons (public domain or Creative Commons; the `image_page` column links each photo's source/license page, and clicking a photo opens it). Coaches without a free image on Commons get a placeholder.
 
 ## Data Files
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,15 @@ The current season's schedule on the main page annotates each game with the all-
 
 ## Franchise History Chart
 
-`/history` charts every season since 1921 as one line — win percentage by default (ties count half; early seasons were ~10 games and modern ones 17, so win% reads honestly across eras), with a persisted toggle to raw wins. Championship seasons get gold dots (the 1929–31 standings titles are hardcoded; every later title is "won the season's final playoff game"), perfect seasons get a white ring, coaching-era bands (Lambeau, Lombardi, Holmgren, McCarthy, LaFleur) sit behind the line, hovering shows the record, and clicking a season opens its page. A compact sparkline of the same chart sits under the answer on the main page (the viewed season marked in white) and links to `/history`.
+`/history` charts every season since 1921 as one line — win percentage by default (ties count half; early seasons were ~10 games and modern ones 17, so win% reads honestly across eras). Any combination of metrics can be plotted at once (win %, wins, points for, points against): metrics sharing a scale get a real labeled axis, mixed scales normalize each series to its own range (tooltips carry exact numbers). An "include playoffs" toggle folds postseason games into every metric. Championship seasons get gold dots (the 1929–31 standings titles are hardcoded; every later title is "won the season's final playoff game"), perfect seasons get a white ring, hovering a season shows its record and points, and clicking a season opens its page. Metric selection and playoff inclusion persist like the site's other settings. A compact sparkline of the same chart sits under the answer on the main page (the viewed season marked in white) and links to `/history`.
+
+Coaching-era bands cover the full timeline — every head-coach tenure, alternating shading — and hovering a band's top strip shows that coach's record; clicking it opens `/coaches`.
 
 The chart is built by `history-chart.js`, a pure SVG-string module shared by the page (`history.js`), the homepage sparkline (`main.js`), and the server-rendered social card at `/og/history.png` — all three render identical geometry from `computeSeasonHistory()` in `records-core.js`.
+
+## Head Coaches
+
+`/coaches` lists every Packers head coach in tenure order with regular-season record, win %, playoff record, and championships. Tenures live in `data/packers_coaches.csv` as from/to **dates**, not seasons, so mid-season changes split correctly (Ronzani → Devore/McLean with two games left in 1953; McCarthy → Philbin after week 13 of 2018) — every game is assigned to a coach by date. Championships count for the coach who coached that champion season's final game. Computation lives in `coaches-core.js`, shared by the browser page (`coaches.html` + `coaches.js`) and the web service (`lib/coaches.js`); the social card is at `/og/coaches.png`.
 
 ## Data Files
 

--- a/coaches-core.js
+++ b/coaches-core.js
@@ -32,6 +32,8 @@ export function computeCoaches(rows, tenures, championSeasons) {
 
 	const spans = tenures.map((t) => ({
 		name: t.coach, from: t.from, to: t.to || '9999-12-31',
+		interim: t.interim === '1',
+		image: t.image || null, imagePage: t.image_page || null,
 	}));
 	const coachOf = (date) => spans.find((s) => date >= s.from && date <= s.to)?.name ?? null;
 
@@ -73,6 +75,8 @@ export function computeCoaches(rows, tenures, championSeasons) {
 			const lastSeason = parseInt(list[list.length - 1].season, 10);
 			return {
 				name: s.name, slug: slugifyCoach(s.name),
+				interim: s.interim,
+				image: s.image, imagePage: s.imagePage,
 				firstSeason, lastSeason,
 				tenure: firstSeason === lastSeason ? String(firstSeason) : `${firstSeason}–${lastSeason}`,
 				games: list.length,

--- a/coaches-core.js
+++ b/coaches-core.js
@@ -1,0 +1,101 @@
+// Shared (browser + node) head-coach records, computed by assigning every
+// game to a coaching tenure by date. Tenures come from
+// data/packers_coaches.csv (from/to dates, so mid-season changes like
+// Ronzani -> Devore/McLean in 1953 or McCarthy -> Philbin in 2018 split
+// correctly). Pure functions only.
+import { rec, splitCsvLine } from './records-core.js';
+
+export const slugifyCoach = (name) =>
+	name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+export function parseCoachesCsv(raw) {
+	const lines = raw.trim().split('\n');
+	const headers = splitCsvLine(lines[0]);
+	return lines.slice(1).map((l) => {
+		const v = splitCsvLine(l); const o = {};
+		headers.forEach((h, i) => { o[h] = v[i] ?? ''; });
+		return o;
+	});
+}
+
+const RESULTS = new Set(['WIN', 'LOSS', 'TIE']);
+
+// games: parsed packers_games.csv rows. tenures: parsed packers_coaches.csv
+// rows ({coach, from, to}; empty to = present). Returns { coaches, bySlug },
+// coaches in tenure order. A championship counts for the coach who coached
+// that champion season's final game.
+export function computeCoaches(rows, tenures, championSeasons) {
+	const games = rows
+		.filter((g) => RESULTS.has(g['Packers Win']))
+		.slice()
+		.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+	const spans = tenures.map((t) => ({
+		name: t.coach, from: t.from, to: t.to || '9999-12-31',
+	}));
+	const coachOf = (date) => spans.find((s) => date >= s.from && date <= s.to)?.name ?? null;
+
+	const byCoach = new Map(spans.map((s) => [s.name, []]));
+	for (const g of games) {
+		const name = coachOf(g.date);
+		if (name) byCoach.get(name).push(g);
+	}
+
+	// Champion season -> coach of that season's final game.
+	const titleCount = new Map();
+	const bySeason = new Map();
+	for (const g of games) {
+		const yr = parseInt(g.season, 10);
+		if (!bySeason.has(yr) || g.date > bySeason.get(yr).date) bySeason.set(yr, g);
+	}
+	for (const yr of championSeasons) {
+		const finale = bySeason.get(yr);
+		const name = finale && coachOf(finale.date);
+		if (name) titleCount.set(name, (titleCount.get(name) || 0) + 1);
+	}
+
+	const coaches = spans
+		.filter((s) => byCoach.get(s.name).length > 0)
+		.map((s) => {
+			const list = byCoach.get(s.name);
+			// Coach records follow convention: regular season, playoffs split out.
+			const reg = { WIN: 0, LOSS: 0, TIE: 0 };
+			const playoff = { WIN: 0, LOSS: 0, TIE: 0 };
+			let pf = 0, pa = 0;
+			for (const g of list) {
+				(g.regular_season === '1' ? reg : playoff)[g['Packers Win']]++;
+				pf += parseInt(g.packers_score, 10) || 0;
+				pa += parseInt(g.opponent_score, 10) || 0;
+			}
+			const regGames = reg.WIN + reg.LOSS + reg.TIE;
+			const playoffGames = playoff.WIN + playoff.LOSS + playoff.TIE;
+			const firstSeason = parseInt(list[0].season, 10);
+			const lastSeason = parseInt(list[list.length - 1].season, 10);
+			return {
+				name: s.name, slug: slugifyCoach(s.name),
+				firstSeason, lastSeason,
+				tenure: firstSeason === lastSeason ? String(firstSeason) : `${firstSeason}–${lastSeason}`,
+				games: list.length,
+				wins: reg.WIN, losses: reg.LOSS, ties: reg.TIE,
+				record: rec(reg.WIN, reg.LOSS, reg.TIE),
+				winPct: regGames ? (reg.WIN + reg.TIE / 2) / regGames : 0,
+				playoffGames,
+				playoffRecord: playoffGames ? rec(playoff.WIN, playoff.LOSS, playoff.TIE) : null,
+				pf, pa,
+				titles: titleCount.get(s.name) || 0,
+			};
+		});
+
+	return { coaches, bySlug: new Map(coaches.map((c) => [c.slug, c])) };
+}
+
+// Meta copy for the /coaches page, shared by server OG meta and client share.
+export function coachesCopy(data) {
+	const { coaches } = data;
+	const wins = [...coaches].sort((a, b) => b.wins - a.wins)[0];
+	const titles = coaches.reduce((s, c) => s + c.titles, 0);
+	return {
+		title: `Packers Head Coaches, ${coaches[0].firstSeason}–present`,
+		desc: `Every Green Bay Packers head coach and their record — ${coaches.length} of them, ${titles} championships. Most wins: ${wins.name} (${wins.record}).`,
+	};
+}

--- a/coaches-core.js
+++ b/coaches-core.js
@@ -56,7 +56,17 @@ export function computeCoaches(rows, tenures, championSeasons) {
 		if (name) titleCount.set(name, (titleCount.get(name) || 0) + 1);
 	}
 
-	const coaches = spans
+	// Coach numbering: regular head coaches count 1..N; interim stints get a
+	// fractional number under the preceding regular coach (McCarthy is #14,
+	// Philbin #14.1) so the official count stays intact and sorting works.
+	let regularNum = 0, interimNum = 0;
+	const numbered = spans.map((s) => {
+		if (s.interim) { interimNum++; return { ...s, num: regularNum + interimNum / 10 }; }
+		regularNum++; interimNum = 0;
+		return { ...s, num: regularNum };
+	});
+
+	const coaches = numbered
 		.filter((s) => byCoach.get(s.name).length > 0)
 		.map((s) => {
 			const list = byCoach.get(s.name);
@@ -76,6 +86,8 @@ export function computeCoaches(rows, tenures, championSeasons) {
 			return {
 				name: s.name, slug: slugifyCoach(s.name),
 				interim: s.interim,
+				num: s.num,
+				numLabel: s.interim ? s.num.toFixed(1) : String(s.num),
 				image: s.image, imagePage: s.imagePage,
 				firstSeason, lastSeason,
 				tenure: firstSeason === lastSeason ? String(firstSeason) : `${firstSeason}–${lastSeason}`,
@@ -84,6 +96,7 @@ export function computeCoaches(rows, tenures, championSeasons) {
 				record: rec(reg.WIN, reg.LOSS, reg.TIE),
 				winPct: regGames ? (reg.WIN + reg.TIE / 2) / regGames : 0,
 				playoffGames,
+				playoffWins: playoff.WIN,
 				playoffRecord: playoffGames ? rec(playoff.WIN, playoff.LOSS, playoff.TIE) : null,
 				pf, pa,
 				titles: titleCount.get(s.name) || 0,
@@ -96,10 +109,11 @@ export function computeCoaches(rows, tenures, championSeasons) {
 // Meta copy for the /coaches page, shared by server OG meta and client share.
 export function coachesCopy(data) {
 	const { coaches } = data;
+	const regular = coaches.filter((c) => !c.interim).length;
 	const wins = [...coaches].sort((a, b) => b.wins - a.wins)[0];
 	const titles = coaches.reduce((s, c) => s + c.titles, 0);
 	return {
 		title: `Packers Head Coaches, ${coaches[0].firstSeason}–present`,
-		desc: `Every Green Bay Packers head coach and their record — ${coaches.length} of them, ${titles} championships. Most wins: ${wins.name} (${wins.record}).`,
+		desc: `Every Green Bay Packers head coach and their record — ${regular} of them (plus interim stints), ${titles} championships. Most wins: ${wins.name} (${wins.record}).`,
 	};
 }

--- a/coaches.html
+++ b/coaches.html
@@ -18,11 +18,15 @@
         <a href="/" class="records-back"><i class="mdi mdi-arrow-left"></i> Are the Packers Undefeated?</a>
         <h1 class="records-title">Head Coaches</h1>
         <p id="coaches-subtitle" class="records-subtitle"></p>
+        <div class="h2h-controls">
+            <label class="h2h-check"><input type="checkbox" id="coaches-interim" checked> Include interim coaches</label>
+        </div>
         <div id="coaches-table-wrap" class="h2h-table-wrap">
             <div class="loading">Loading coaches...</div>
         </div>
         <p class="history-legend">
-            <span class="history-legend-item">Records are regular season; interim and partial-season stints are tracked by exact dates</span>
+            <span class="history-legend-item">* interim · records are regular season; partial-season stints are tracked by exact dates</span>
+            <span class="history-legend-item">Photos: Wikimedia Commons (public domain / CC) — click a photo for source &amp; license</span>
         </p>
         <div class="record-share" id="coaches-share"></div>
     </div>

--- a/coaches.html
+++ b/coaches.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Packers Head Coaches</title>
+    <meta name="description" content="Every Green Bay Packers head coach and their record, from Curly Lambeau to today.">
+    <meta property="og:title" content="Packers Head Coaches">
+    <meta property="og:description" content="Every Green Bay Packers head coach and their record, from Curly Lambeau to today.">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
+    <!-- Absolute asset paths: this shell is also reachable at /coaches/, where relative paths would break. -->
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="container records-container">
+        <a href="/" class="records-back"><i class="mdi mdi-arrow-left"></i> Are the Packers Undefeated?</a>
+        <h1 class="records-title">Head Coaches</h1>
+        <p id="coaches-subtitle" class="records-subtitle"></p>
+        <div id="coaches-table-wrap" class="h2h-table-wrap">
+            <div class="loading">Loading coaches...</div>
+        </div>
+        <p class="history-legend">
+            <span class="history-legend-item">Records are regular season; interim and partial-season stints are tracked by exact dates</span>
+        </p>
+        <div class="record-share" id="coaches-share"></div>
+    </div>
+
+    <footer class="site-footer">
+        <a href="https://github.com/rptetzloff/AreThePackersUndefeated" target="_blank" rel="noopener noreferrer" class="github-link">
+            <i class="mdi mdi-github"></i>
+            View on GitHub
+        </a>
+    </footer>
+
+    <script src="/coaches.js" type="module"></script>
+</body>
+</html>

--- a/coaches.html
+++ b/coaches.html
@@ -28,7 +28,16 @@
             <span class="history-legend-item">* interim · records are regular season; partial-season stints are tracked by exact dates</span>
             <span class="history-legend-item">Photos: Wikimedia Commons (public domain / CC) — click a photo for source &amp; license</span>
         </p>
-        <div class="record-share" id="coaches-share"></div>
+        <div class="share-section" id="coaches-share"></div>
+    </div>
+
+    <div id="lightbox" class="lightbox" role="dialog" aria-modal="true" aria-label="Coach photo" hidden>
+        <button id="lightbox-close" class="lightbox-close" aria-label="Close"><i class="mdi mdi-close"></i></button>
+        <img id="lightbox-img" src="" alt="">
+        <div class="lightbox-info">
+            <p id="lightbox-caption" class="lightbox-caption"></p>
+            <p id="lightbox-license" class="lightbox-license"></p>
+        </div>
     </div>
 
     <footer class="site-footer">

--- a/coaches.js
+++ b/coaches.js
@@ -1,0 +1,51 @@
+// Head Coaches page: every Packers head coach in tenure order with their
+// record, computed from the shared coaches-core.js (games assigned to
+// tenures by exact dates, so mid-season changes split correctly).
+import { parseGamesCsv, computeSeasonHistory, esc } from './records-core.js';
+import { parseCoachesCsv, computeCoaches, coachesCopy } from './coaches-core.js';
+import { shareButtonsHtml, wireShareRow } from './share-core.js';
+
+const pct = (p) => (p >= 1 ? '1.000' : p.toFixed(3).replace(/^0/, ''));
+
+function tableHtml(coaches) {
+	const rows = coaches.map((c) => `
+		<tr>
+			<td>${esc(c.name)}</td>
+			<td class="h2h-num"><a href="/${c.firstSeason}">${esc(c.tenure)}</a></td>
+			<td class="h2h-num">${esc(c.record)}</td>
+			<td class="h2h-num">${pct(c.winPct)}</td>
+			<td class="h2h-num">${c.playoffRecord ? esc(c.playoffRecord) : '—'}</td>
+			<td class="h2h-num">${c.titles || '—'}</td>
+		</tr>`).join('');
+	return `<table class="h2h-table">
+		<thead><tr><th>Coach</th><th class="h2h-num">Tenure</th><th class="h2h-num">Record</th><th class="h2h-num">Win %</th><th class="h2h-num">Playoffs</th><th class="h2h-num">Titles</th></tr></thead>
+		<tbody>${rows}</tbody>
+	</table>`;
+}
+
+async function init() {
+	const wrap = document.getElementById('coaches-table-wrap');
+	try {
+		const [gamesRes, coachesRes] = await Promise.all([
+			fetch('/data/packers_games.csv'),
+			fetch('/data/packers_coaches.csv'),
+		]);
+		if (!gamesRes.ok || !coachesRes.ok) throw new Error('CSV fetch failed');
+		const rows = parseGamesCsv(await gamesRes.text());
+		const champions = computeSeasonHistory(rows).filter((s) => s.champion).map((s) => s.season);
+		const data = computeCoaches(rows, parseCoachesCsv(await coachesRes.text()), champions);
+
+		document.getElementById('coaches-subtitle').textContent =
+			`Green Bay Packers · ${data.coaches.length} head coaches since ${data.coaches[0].firstSeason}`;
+		wrap.innerHTML = tableHtml(data.coaches);
+
+		const share = document.getElementById('coaches-share');
+		share.innerHTML = shareButtonsHtml('share-btn record-share-btn');
+		wireShareRow(share, coachesCopy(data).desc, `${window.location.origin}/coaches`);
+	} catch (e) {
+		wrap.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
+		console.error(e);
+	}
+}
+
+init();

--- a/coaches.js
+++ b/coaches.js
@@ -7,18 +7,27 @@ import { shareButtonsHtml, wireShareRow } from './share-core.js';
 
 const pct = (p) => (p >= 1 ? '1.000' : p.toFixed(3).replace(/^0/, ''));
 
+function photoHtml(c) {
+	if (!c.image) return '<span class="coach-photo coach-photo-none"><i class="mdi mdi-account"></i></span>';
+	// Linking to the Commons file page carries the attribution/license.
+	return `<a href="${esc(c.imagePage || c.image)}" target="_blank" rel="noopener noreferrer" title="Photo: Wikimedia Commons (click for source & license)">
+		<img class="coach-photo" src="${esc(c.image)}" alt="${esc(c.name)}">
+	</a>`;
+}
+
 function tableHtml(coaches) {
 	const rows = coaches.map((c) => `
 		<tr>
-			<td>${esc(c.name)}</td>
+			<td class="coach-photo-cell">${photoHtml(c)}</td>
+			<td>${esc(c.name)}${c.interim ? '<span class="coach-interim" title="Interim">*</span>' : ''}</td>
 			<td class="h2h-num"><a href="/${c.firstSeason}">${esc(c.tenure)}</a></td>
 			<td class="h2h-num">${esc(c.record)}</td>
 			<td class="h2h-num">${pct(c.winPct)}</td>
 			<td class="h2h-num">${c.playoffRecord ? esc(c.playoffRecord) : '—'}</td>
 			<td class="h2h-num">${c.titles || '—'}</td>
 		</tr>`).join('');
-	return `<table class="h2h-table">
-		<thead><tr><th>Coach</th><th class="h2h-num">Tenure</th><th class="h2h-num">Record</th><th class="h2h-num">Win %</th><th class="h2h-num">Playoffs</th><th class="h2h-num">Titles</th></tr></thead>
+	return `<table class="h2h-table coaches-table">
+		<thead><tr><th></th><th>Coach</th><th class="h2h-num">Tenure</th><th class="h2h-num">Record</th><th class="h2h-num">Win %</th><th class="h2h-num">Playoffs</th><th class="h2h-num">Titles</th></tr></thead>
 		<tbody>${rows}</tbody>
 	</table>`;
 }
@@ -37,7 +46,18 @@ async function init() {
 
 		document.getElementById('coaches-subtitle').textContent =
 			`Green Bay Packers · ${data.coaches.length} head coaches since ${data.coaches[0].firstSeason}`;
-		wrap.innerHTML = tableHtml(data.coaches);
+
+		// Interim exclusion persists like the site's other settings.
+		const interimBox = document.getElementById('coaches-interim');
+		interimBox.checked = localStorage.getItem('coachesShowInterim') !== 'false';
+		const renderTable = () => {
+			wrap.innerHTML = tableHtml(interimBox.checked ? data.coaches : data.coaches.filter((c) => !c.interim));
+		};
+		interimBox.addEventListener('change', () => {
+			localStorage.setItem('coachesShowInterim', String(interimBox.checked));
+			renderTable();
+		});
+		renderTable();
 
 		const share = document.getElementById('coaches-share');
 		share.innerHTML = shareButtonsHtml('share-btn record-share-btn');

--- a/coaches.js
+++ b/coaches.js
@@ -1,23 +1,25 @@
 // Head Coaches page: every Packers head coach in tenure order with their
 // record, computed from the shared coaches-core.js (games assigned to
-// tenures by exact dates, so mid-season changes split correctly).
+// tenures by exact dates, so mid-season changes split correctly). Columns
+// sort on click; coach photos open in the site's lightbox.
 import { parseGamesCsv, computeSeasonHistory, esc } from './records-core.js';
 import { parseCoachesCsv, computeCoaches, coachesCopy } from './coaches-core.js';
 import { shareButtonsHtml, wireShareRow } from './share-core.js';
+import { sortItems, wireSortHeaders } from './sortable.js';
 
 const pct = (p) => (p >= 1 ? '1.000' : p.toFixed(3).replace(/^0/, ''));
 
 function photoHtml(c) {
 	if (!c.image) return '<span class="coach-photo coach-photo-none"><i class="mdi mdi-account"></i></span>';
-	// Linking to the Commons file page carries the attribution/license.
-	return `<a href="${esc(c.imagePage || c.image)}" target="_blank" rel="noopener noreferrer" title="Photo: Wikimedia Commons (click for source & license)">
+	return `<a href="${esc(c.imagePage || c.image)}" class="coach-photo-link" data-coach="${esc(c.slug)}" title="View photo">
 		<img class="coach-photo" src="${esc(c.image)}" alt="${esc(c.name)}">
 	</a>`;
 }
 
-function tableHtml(coaches) {
+function tableHtml(coaches, state) {
 	const rows = coaches.map((c) => `
 		<tr>
+			<td class="h2h-num">${esc(c.numLabel)}</td>
 			<td class="coach-photo-cell">${photoHtml(c)}</td>
 			<td>${esc(c.name)}${c.interim ? '<span class="coach-interim" title="Interim">*</span>' : ''}</td>
 			<td class="h2h-num"><a href="/${c.firstSeason}">${esc(c.tenure)}</a></td>
@@ -27,9 +29,45 @@ function tableHtml(coaches) {
 			<td class="h2h-num">${c.titles || '—'}</td>
 		</tr>`).join('');
 	return `<table class="h2h-table coaches-table">
-		<thead><tr><th></th><th>Coach</th><th class="h2h-num">Tenure</th><th class="h2h-num">Record</th><th class="h2h-num">Win %</th><th class="h2h-num">Playoffs</th><th class="h2h-num">Titles</th></tr></thead>
+		<thead><tr>
+			<th class="h2h-num" data-sort="num" data-dir="asc">#</th>
+			<th></th>
+			<th data-sort="name" data-dir="asc">Coach</th>
+			<th class="h2h-num" data-sort="firstSeason" data-dir="asc">Tenure</th>
+			<th class="h2h-num" data-sort="wins">Record</th>
+			<th class="h2h-num" data-sort="winPct">Win %</th>
+			<th class="h2h-num" data-sort="playoffWins">Playoffs</th>
+			<th class="h2h-num" data-sort="titles">Titles</th>
+		</tr></thead>
 		<tbody>${rows}</tbody>
 	</table>`;
+}
+
+// Reuse the site's lightbox (same markup/classes as the season photo viewer);
+// caption is the coach, license line links to the Commons source page.
+function wireLightbox(coaches) {
+	const lightbox = document.getElementById('lightbox');
+	const bySlug = new Map(coaches.map((c) => [c.slug, c]));
+	document.getElementById('coaches-table-wrap').addEventListener('click', (e) => {
+		const link = e.target.closest('.coach-photo-link');
+		if (!link) return;
+		e.preventDefault();
+		const c = bySlug.get(link.dataset.coach);
+		document.getElementById('lightbox-img').src = c.image;
+		document.getElementById('lightbox-img').alt = c.name;
+		document.getElementById('lightbox-caption').textContent = `${c.name} · ${c.tenure}`;
+		document.getElementById('lightbox-license').innerHTML =
+			`Photo: <a href="${esc(c.imagePage)}" target="_blank" rel="noopener noreferrer">Wikimedia Commons — source &amp; license</a>`;
+		lightbox.hidden = false;
+	});
+	const close = () => { lightbox.hidden = true; };
+	document.getElementById('lightbox-close').addEventListener('click', close);
+	lightbox.addEventListener('click', (e) => {
+		if (e.target === lightbox || e.target === document.getElementById('lightbox-img')) close();
+	});
+	document.addEventListener('keydown', (e) => {
+		if (e.key === 'Escape' && !lightbox.hidden) close();
+	});
 }
 
 async function init() {
@@ -45,23 +83,27 @@ async function init() {
 		const data = computeCoaches(rows, parseCoachesCsv(await coachesRes.text()), champions);
 
 		document.getElementById('coaches-subtitle').textContent =
-			`Green Bay Packers · ${data.coaches.length} head coaches since ${data.coaches[0].firstSeason}`;
+			`Green Bay Packers · ${data.coaches.filter((c) => !c.interim).length} head coaches since ${data.coaches[0].firstSeason}`;
 
 		// Interim exclusion persists like the site's other settings.
 		const interimBox = document.getElementById('coaches-interim');
 		interimBox.checked = localStorage.getItem('coachesShowInterim') !== 'false';
+		const sortState = { key: 'num', dir: 'asc' };
 		const renderTable = () => {
-			wrap.innerHTML = tableHtml(interimBox.checked ? data.coaches : data.coaches.filter((c) => !c.interim));
+			const items = interimBox.checked ? data.coaches : data.coaches.filter((c) => !c.interim);
+			wrap.innerHTML = tableHtml(sortItems(items, sortState), sortState);
+			wireSortHeaders(wrap, sortState, renderTable);
 		};
 		interimBox.addEventListener('change', () => {
 			localStorage.setItem('coachesShowInterim', String(interimBox.checked));
 			renderTable();
 		});
 		renderTable();
+		wireLightbox(data.coaches);
 
 		const share = document.getElementById('coaches-share');
-		share.innerHTML = shareButtonsHtml('share-btn record-share-btn');
-		wireShareRow(share, coachesCopy(data).desc, `${window.location.origin}/coaches`);
+		share.innerHTML = shareButtonsHtml('share-btn', { labels: true });
+		wireShareRow(share, coachesCopy(data).desc, `${window.location.origin}/coaches`, { labels: true });
 	} catch (e) {
 		wrap.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
 		console.error(e);

--- a/data/packers_coaches.csv
+++ b/data/packers_coaches.csv
@@ -1,0 +1,18 @@
+coach,from,to
+Curly Lambeau,1921-01-01,1950-01-31
+Gene Ronzani,1950-02-01,1953-11-26
+Hugh Devore & Scooter McLean,1953-11-27,1954-01-31
+Lisle Blackbourn,1954-02-01,1958-01-31
+Scooter McLean,1958-02-01,1959-01-31
+Vince Lombardi,1959-02-01,1968-01-31
+Phil Bengtson,1968-02-01,1971-01-31
+Dan Devine,1971-02-01,1975-01-31
+Bart Starr,1975-02-01,1984-01-31
+Forrest Gregg,1984-02-01,1988-01-31
+Lindy Infante,1988-02-01,1992-01-31
+Mike Holmgren,1992-02-01,1999-01-31
+Ray Rhodes,1999-02-01,2000-01-31
+Mike Sherman,2000-02-01,2006-01-31
+Mike McCarthy,2006-02-01,2018-12-02
+Joe Philbin,2018-12-03,2019-01-31
+Matt LaFleur,2019-02-01,

--- a/data/packers_coaches.csv
+++ b/data/packers_coaches.csv
@@ -1,18 +1,18 @@
-coach,from,to
-Curly Lambeau,1921-01-01,1950-01-31
-Gene Ronzani,1950-02-01,1953-11-26
-Hugh Devore & Scooter McLean,1953-11-27,1954-01-31
-Lisle Blackbourn,1954-02-01,1958-01-31
-Scooter McLean,1958-02-01,1959-01-31
-Vince Lombardi,1959-02-01,1968-01-31
-Phil Bengtson,1968-02-01,1971-01-31
-Dan Devine,1971-02-01,1975-01-31
-Bart Starr,1975-02-01,1984-01-31
-Forrest Gregg,1984-02-01,1988-01-31
-Lindy Infante,1988-02-01,1992-01-31
-Mike Holmgren,1992-02-01,1999-01-31
-Ray Rhodes,1999-02-01,2000-01-31
-Mike Sherman,2000-02-01,2006-01-31
-Mike McCarthy,2006-02-01,2018-12-02
-Joe Philbin,2018-12-03,2019-01-31
-Matt LaFleur,2019-02-01,
+coach,from,to,interim,image,image_page
+Curly Lambeau,1921-01-01,1950-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/CurlyLambeauNotreDame.jpg/250px-CurlyLambeauNotreDame.jpg,https://commons.wikimedia.org/wiki/File:CurlyLambeauNotreDame.jpg
+Gene Ronzani,1950-02-01,1953-11-26,0,https://upload.wikimedia.org/wikipedia/commons/7/7c/Gene_Ronzani_-_1952_Bowman_Large.jpg,https://commons.wikimedia.org/wiki/File:Gene_Ronzani_-_1952_Bowman_Large.jpg
+Hugh Devore & Scooter McLean,1953-11-27,1954-01-31,1,,
+Lisle Blackbourn,1954-02-01,1958-01-31,0,https://upload.wikimedia.org/wikipedia/commons/a/a8/Lisle_Blackbourn_%28page_196_crop%29.jpg,https://commons.wikimedia.org/wiki/File:Lisle_Blackbourn_(page_196_crop).jpg
+Scooter McLean,1958-02-01,1959-01-31,0,,
+Vince Lombardi,1959-02-01,1968-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Vince_Lombardi_%281913-1970%29_in_1964_Crop.jpg/250px-Vince_Lombardi_%281913-1970%29_in_1964_Crop.jpg,https://commons.wikimedia.org/wiki/File:Vince_Lombardi_(1913-1970)_in_1964_Crop.jpg
+Phil Bengtson,1968-02-01,1971-01-31,0,,
+Dan Devine,1971-02-01,1975-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Dan_Devine_1965.jpg/250px-Dan_Devine_1965.jpg,https://commons.wikimedia.org/wiki/File:Dan_Devine_1965.jpg
+Bart Starr,1975-02-01,1984-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Bart_starr_bw.jpg/250px-Bart_starr_bw.jpg,https://commons.wikimedia.org/wiki/File:Bart_starr_bw.jpg
+Forrest Gregg,1984-02-01,1988-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/ForrestGreggGB.png/250px-ForrestGreggGB.png,https://commons.wikimedia.org/wiki/File:ForrestGreggGB.png
+Lindy Infante,1988-02-01,1992-01-31,0,,
+Mike Holmgren,1992-02-01,1999-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Mike_Holmgren_2004_Portrait_crop.jpg/250px-Mike_Holmgren_2004_Portrait_crop.jpg,https://commons.wikimedia.org/wiki/File:Mike_Holmgren_2004_Portrait_crop.jpg
+Ray Rhodes,1999-02-01,2000-01-31,0,,
+Mike Sherman,2000-02-01,2006-01-31,0,https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/MikeSherman2003.jpg/250px-MikeSherman2003.jpg,https://commons.wikimedia.org/wiki/File:MikeSherman2003.jpg
+Mike McCarthy,2006-02-01,2018-12-02,0,https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/Mike_McCarthy_%28cropped%29.jpg/250px-Mike_McCarthy_%28cropped%29.jpg,https://commons.wikimedia.org/wiki/File:Mike_McCarthy_(cropped).jpg
+Joe Philbin,2018-12-03,2019-01-31,1,https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/Joe_Philbin.jpg/250px-Joe_Philbin.jpg,https://commons.wikimedia.org/wiki/File:Joe_Philbin.jpg
+Matt LaFleur,2019-02-01,,0,https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/LaFleur_%28cropped%29.jpg/250px-LaFleur_%28cropped%29.jpg,https://commons.wikimedia.org/wiki/File:LaFleur_(cropped).jpg

--- a/history-chart.js
+++ b/history-chart.js
@@ -1,0 +1,106 @@
+// Shared (browser + node) SVG builder for the franchise-history chart: one
+// point per season. Pure string output, no DOM — the /history page, the
+// homepage sparkline, and the server-rendered social card all use it.
+
+const GOLD = '#FFB612';
+const WHITE = '#FFFFFF';
+const DARK = '#152A1E';
+
+// Coaching-era bands for the full chart (notable tenures only).
+export const ERAS = [
+	{ label: 'Lambeau', from: 1921, to: 1949 },
+	{ label: 'Lombardi', from: 1959, to: 1967 },
+	{ label: 'Holmgren', from: 1992, to: 1998 },
+	{ label: 'McCarthy', from: 2006, to: 2018 },
+	{ label: 'LaFleur', from: 2019, to: 9999 },
+];
+
+// history: computeSeasonHistory() output. Options:
+//   width/height  — SVG pixel size (also the viewBox)
+//   metric        — 'winPct' | 'wins'
+//   axes          — draw y-axis labels and gridlines
+//   eras          — era bands (array like ERAS) or null
+//   markers       — championship dots
+//   hitAreas      — invisible per-season hover/click columns (data-season)
+//   highlight     — a season number to mark with a distinct dot, or null
+//   emoji         — trophy glyphs above championship dots (browser only;
+//                   the PNG renderer has no emoji font)
+export function buildChartSvg(history, {
+	width = 1000, height = 420,
+	metric = 'winPct',
+	axes = true,
+	eras = null,
+	markers = true,
+	hitAreas = false,
+	highlight = null,
+	emoji = false,
+} = {}) {
+	const pad = axes
+		? { l: 46, r: 16, t: emoji ? 26 : 16, b: 30 }
+		: { l: 4, r: 4, t: emoji ? 16 : 6, b: 6 };
+	const plotW = width - pad.l - pad.r;
+	const plotH = height - pad.t - pad.b;
+	const first = history[0].season, last = history[history.length - 1].season;
+	const maxY = metric === 'wins' ? Math.max(...history.map((s) => s.wins)) : 1;
+	const x = (season) => pad.l + ((season - first) / (last - first)) * plotW;
+	const y = (v) => pad.t + (1 - v / maxY) * plotH;
+	const val = (s) => (metric === 'wins' ? s.wins : s.winPct);
+
+	const parts = [];
+
+	if (eras) {
+		for (const era of eras) {
+			const from = Math.max(era.from, first), to = Math.min(era.to, last);
+			if (to < from) continue;
+			parts.push(`<rect x="${x(from).toFixed(1)}" y="${pad.t}" width="${(x(to) - x(from)).toFixed(1)}" height="${plotH}" fill="${GOLD}" opacity="0.07"/>`);
+			parts.push(`<text x="${((x(from) + x(to)) / 2).toFixed(1)}" y="${pad.t + 14}" font-size="12" fill="${GOLD}" opacity="0.7" text-anchor="middle">${era.label}</text>`);
+		}
+	}
+
+	if (axes) {
+		const ticks = metric === 'wins'
+			? [0, Math.round(maxY / 2), maxY]
+			: [0, 0.25, 0.5, 0.75, 1];
+		for (const tv of ticks) {
+			const ty = y(tv);
+			const mid = metric === 'winPct' && tv === 0.5;
+			parts.push(`<line x1="${pad.l}" y1="${ty.toFixed(1)}" x2="${width - pad.r}" y2="${ty.toFixed(1)}" stroke="${WHITE}" opacity="${mid ? 0.3 : 0.08}"${mid ? ' stroke-dasharray="4 4"' : ''}/>`);
+			parts.push(`<text x="${pad.l - 8}" y="${(ty + 4).toFixed(1)}" font-size="12" fill="${WHITE}" opacity="0.55" text-anchor="end">${metric === 'wins' ? tv : tv === 0 || tv === 1 ? `${tv}` : `.${tv * 100}`}</text>`);
+		}
+		for (let decade = Math.ceil(first / 20) * 20; decade <= last; decade += 20) {
+			parts.push(`<text x="${x(decade).toFixed(1)}" y="${height - 8}" font-size="12" fill="${WHITE}" opacity="0.55" text-anchor="middle">${decade}</text>`);
+		}
+	} else if (metric === 'winPct') {
+		parts.push(`<line x1="${pad.l}" y1="${y(0.5).toFixed(1)}" x2="${width - pad.r}" y2="${y(0.5).toFixed(1)}" stroke="${WHITE}" opacity="0.25" stroke-dasharray="3 3"/>`);
+	}
+
+	const pts = history.map((s) => `${x(s.season).toFixed(1)},${y(val(s)).toFixed(1)}`).join(' ');
+	parts.push(`<polyline points="${pts}" fill="none" stroke="${GOLD}" stroke-width="${axes ? 2 : 1.5}" stroke-linejoin="round"/>`);
+
+	if (markers) {
+		for (const s of history) {
+			if (s.undefeated && !s.champion) {
+				parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${y(val(s)).toFixed(1)}" r="${axes ? 6 : 3.5}" fill="none" stroke="${WHITE}" stroke-width="1.5"/>`);
+			}
+			if (!s.champion) continue;
+			parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${y(val(s)).toFixed(1)}" r="${axes ? 5 : 2.5}" fill="${GOLD}" stroke="${DARK}" stroke-width="1.5"/>`);
+			if (emoji) {
+				parts.push(`<text x="${x(s.season).toFixed(1)}" y="${(y(val(s)) - (axes ? 10 : 6)).toFixed(1)}" font-size="${axes ? 14 : 9}" text-anchor="middle">🏆</text>`);
+			}
+		}
+	}
+
+	if (highlight != null) {
+		const s = history.find((h) => h.season === highlight);
+		if (s) parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${y(val(s)).toFixed(1)}" r="${axes ? 6 : 3.5}" fill="${WHITE}" stroke="${DARK}" stroke-width="1.5"/>`);
+	}
+
+	if (hitAreas) {
+		const step = plotW / (last - first);
+		for (const s of history) {
+			parts.push(`<rect data-season="${s.season}" x="${(x(s.season) - step / 2).toFixed(1)}" y="0" width="${step.toFixed(1)}" height="${height}" fill="transparent" style="cursor:pointer"/>`);
+		}
+	}
+
+	return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">${parts.join('')}</svg>`;
+}

--- a/history-chart.js
+++ b/history-chart.js
@@ -6,28 +6,32 @@ const GOLD = '#FFB612';
 const WHITE = '#FFFFFF';
 const DARK = '#152A1E';
 
-// Coaching-era bands for the full chart (notable tenures only).
-export const ERAS = [
-	{ label: 'Lambeau', from: 1921, to: 1949 },
-	{ label: 'Lombardi', from: 1959, to: 1967 },
-	{ label: 'Holmgren', from: 1992, to: 1998 },
-	{ label: 'McCarthy', from: 2006, to: 2018 },
-	{ label: 'LaFleur', from: 2019, to: 9999 },
-];
+// Plottable per-season metrics. Metrics in the same scale group share a real
+// labeled axis; mixing groups falls back to per-series normalization (shapes
+// stay honest, tooltips carry the exact numbers).
+export const METRICS = {
+	winPct: { label: 'Win %', color: GOLD, group: 'pct' },
+	wins: { label: 'Wins', color: WHITE, group: 'count' },
+	pf: { label: 'Points For', color: '#7FC4FF', group: 'points' },
+	pa: { label: 'Points Against', color: '#FF6B6B', group: 'points' },
+};
 
 // history: computeSeasonHistory() output. Options:
 //   width/height  — SVG pixel size (also the viewBox)
-//   metric        — 'winPct' | 'wins'
+//   metrics       — array of METRICS keys to plot (first is the primary line)
 //   axes          — draw y-axis labels and gridlines
-//   eras          — era bands (array like ERAS) or null
-//   markers       — championship dots
+//   eras          — era bands: [{ label, from, to, key }] or null. Bands get a
+//                   hoverable top strip carrying data-era="key" when hitAreas
+//                   is on, so pages can attach coach tooltips.
+//   markers       — championship dots (drawn on the win% line if plotted,
+//                   else the first metric)
 //   hitAreas      — invisible per-season hover/click columns (data-season)
 //   highlight     — a season number to mark with a distinct dot, or null
 //   emoji         — trophy glyphs above championship dots (browser only;
 //                   the PNG renderer has no emoji font)
 export function buildChartSvg(history, {
 	width = 1000, height = 420,
-	metric = 'winPct',
+	metrics = ['winPct'],
 	axes = true,
 	eras = null,
 	markers = true,
@@ -35,70 +39,101 @@ export function buildChartSvg(history, {
 	highlight = null,
 	emoji = false,
 } = {}) {
+	const stripH = eras ? 20 : 0;
 	const pad = axes
-		? { l: 46, r: 16, t: emoji ? 26 : 16, b: 30 }
-		: { l: 4, r: 4, t: emoji ? 16 : 6, b: 6 };
+		? { l: 46, r: 16, t: (emoji ? 26 : 16) + stripH, b: 30 }
+		: { l: 4, r: 4, t: (emoji ? 16 : 6) + stripH, b: 6 };
 	const plotW = width - pad.l - pad.r;
 	const plotH = height - pad.t - pad.b;
 	const first = history[0].season, last = history[history.length - 1].season;
-	const maxY = metric === 'wins' ? Math.max(...history.map((s) => s.wins)) : 1;
 	const x = (season) => pad.l + ((season - first) / (last - first)) * plotW;
-	const y = (v) => pad.t + (1 - v / maxY) * plotH;
-	const val = (s) => (metric === 'wins' ? s.wins : s.winPct);
+
+	// One shared scale when every metric is in the same group; otherwise each
+	// series normalizes to its own max.
+	const groups = new Set(metrics.map((m) => METRICS[m].group));
+	const shared = groups.size === 1;
+	const maxOf = (m) => (METRICS[m].group === 'pct' ? 1 : Math.max(1, ...history.map((s) => s[m])));
+	const sharedMax = shared ? Math.max(...metrics.map(maxOf)) : null;
+	const yFor = (m) => {
+		const max = shared ? sharedMax : maxOf(m);
+		return (v) => pad.t + (1 - v / max) * plotH;
+	};
 
 	const parts = [];
 
 	if (eras) {
+		let i = 0;
 		for (const era of eras) {
-			const from = Math.max(era.from, first), to = Math.min(era.to, last);
+			const from = Math.max(era.from - 0.5, first), to = Math.min(era.to + 0.5, last);
 			if (to < from) continue;
-			parts.push(`<rect x="${x(from).toFixed(1)}" y="${pad.t}" width="${(x(to) - x(from)).toFixed(1)}" height="${plotH}" fill="${GOLD}" opacity="0.07"/>`);
-			parts.push(`<text x="${((x(from) + x(to)) / 2).toFixed(1)}" y="${pad.t + 14}" font-size="12" fill="${GOLD}" opacity="0.7" text-anchor="middle">${era.label}</text>`);
+			const bx = x(from), bw = x(to) - x(from);
+			parts.push(`<rect x="${bx.toFixed(1)}" y="${pad.t - stripH}" width="${bw.toFixed(1)}" height="${(plotH + stripH).toFixed(1)}" fill="${GOLD}" opacity="${i % 2 ? 0.1 : 0.045}"/>`);
+			if (era.label && bw > 54) {
+				parts.push(`<text x="${(bx + bw / 2).toFixed(1)}" y="${pad.t - stripH + 14}" font-size="12" fill="${GOLD}" opacity="0.8" text-anchor="middle">${era.label}</text>`);
+			}
+			i++;
 		}
 	}
 
 	if (axes) {
-		const ticks = metric === 'wins'
-			? [0, Math.round(maxY / 2), maxY]
-			: [0, 0.25, 0.5, 0.75, 1];
-		for (const tv of ticks) {
-			const ty = y(tv);
-			const mid = metric === 'winPct' && tv === 0.5;
-			parts.push(`<line x1="${pad.l}" y1="${ty.toFixed(1)}" x2="${width - pad.r}" y2="${ty.toFixed(1)}" stroke="${WHITE}" opacity="${mid ? 0.3 : 0.08}"${mid ? ' stroke-dasharray="4 4"' : ''}/>`);
-			parts.push(`<text x="${pad.l - 8}" y="${(ty + 4).toFixed(1)}" font-size="12" fill="${WHITE}" opacity="0.55" text-anchor="end">${metric === 'wins' ? tv : tv === 0 || tv === 1 ? `${tv}` : `.${tv * 100}`}</text>`);
+		const axisMax = shared ? sharedMax : null;
+		if (axisMax != null) {
+			const pct = groups.has('pct');
+			const ticks = pct ? [0, 0.25, 0.5, 0.75, 1]
+				: [0, Math.round(axisMax / 2), axisMax];
+			const yy = yFor(metrics[0]);
+			for (const tv of ticks) {
+				const ty = yy(tv);
+				const mid = pct && tv === 0.5;
+				parts.push(`<line x1="${pad.l}" y1="${ty.toFixed(1)}" x2="${width - pad.r}" y2="${ty.toFixed(1)}" stroke="${WHITE}" opacity="${mid ? 0.3 : 0.08}"${mid ? ' stroke-dasharray="4 4"' : ''}/>`);
+				parts.push(`<text x="${pad.l - 8}" y="${(ty + 4).toFixed(1)}" font-size="12" fill="${WHITE}" opacity="0.55" text-anchor="end">${pct ? (tv === 0 || tv === 1 ? `${tv}` : `.${tv * 100}`) : tv}</text>`);
+			}
 		}
 		for (let decade = Math.ceil(first / 20) * 20; decade <= last; decade += 20) {
 			parts.push(`<text x="${x(decade).toFixed(1)}" y="${height - 8}" font-size="12" fill="${WHITE}" opacity="0.55" text-anchor="middle">${decade}</text>`);
 		}
-	} else if (metric === 'winPct') {
-		parts.push(`<line x1="${pad.l}" y1="${y(0.5).toFixed(1)}" x2="${width - pad.r}" y2="${y(0.5).toFixed(1)}" stroke="${WHITE}" opacity="0.25" stroke-dasharray="3 3"/>`);
+	} else if (groups.has('pct')) {
+		const yy = yFor(metrics.find((m) => METRICS[m].group === 'pct'));
+		parts.push(`<line x1="${pad.l}" y1="${yy(0.5).toFixed(1)}" x2="${width - pad.r}" y2="${yy(0.5).toFixed(1)}" stroke="${WHITE}" opacity="0.25" stroke-dasharray="3 3"/>`);
 	}
 
-	const pts = history.map((s) => `${x(s.season).toFixed(1)},${y(val(s)).toFixed(1)}`).join(' ');
-	parts.push(`<polyline points="${pts}" fill="none" stroke="${GOLD}" stroke-width="${axes ? 2 : 1.5}" stroke-linejoin="round"/>`);
+	for (const m of metrics) {
+		const yy = yFor(m);
+		const pts = history.map((s) => `${x(s.season).toFixed(1)},${yy(s[m]).toFixed(1)}`).join(' ');
+		parts.push(`<polyline points="${pts}" fill="none" stroke="${METRICS[m].color}" stroke-width="${axes ? 2 : 1.5}" stroke-linejoin="round"${m === 'pa' ? ' stroke-dasharray="5 3"' : ''}/>`);
+	}
 
+	const markerMetric = metrics.includes('winPct') ? 'winPct' : metrics[0];
+	const my = yFor(markerMetric);
 	if (markers) {
 		for (const s of history) {
 			if (s.undefeated && !s.champion) {
-				parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${y(val(s)).toFixed(1)}" r="${axes ? 6 : 3.5}" fill="none" stroke="${WHITE}" stroke-width="1.5"/>`);
+				parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${my(s[markerMetric]).toFixed(1)}" r="${axes ? 6 : 3.5}" fill="none" stroke="${WHITE}" stroke-width="1.5"/>`);
 			}
 			if (!s.champion) continue;
-			parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${y(val(s)).toFixed(1)}" r="${axes ? 5 : 2.5}" fill="${GOLD}" stroke="${DARK}" stroke-width="1.5"/>`);
+			parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${my(s[markerMetric]).toFixed(1)}" r="${axes ? 5 : 2.5}" fill="${GOLD}" stroke="${DARK}" stroke-width="1.5"/>`);
 			if (emoji) {
-				parts.push(`<text x="${x(s.season).toFixed(1)}" y="${(y(val(s)) - (axes ? 10 : 6)).toFixed(1)}" font-size="${axes ? 14 : 9}" text-anchor="middle">🏆</text>`);
+				parts.push(`<text x="${x(s.season).toFixed(1)}" y="${(my(s[markerMetric]) - (axes ? 10 : 6)).toFixed(1)}" font-size="${axes ? 14 : 9}" text-anchor="middle">🏆</text>`);
 			}
 		}
 	}
 
 	if (highlight != null) {
 		const s = history.find((h) => h.season === highlight);
-		if (s) parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${y(val(s)).toFixed(1)}" r="${axes ? 6 : 3.5}" fill="${WHITE}" stroke="${DARK}" stroke-width="1.5"/>`);
+		if (s) parts.push(`<circle cx="${x(s.season).toFixed(1)}" cy="${my(s[markerMetric]).toFixed(1)}" r="${axes ? 6 : 3.5}" fill="${WHITE}" stroke="${DARK}" stroke-width="1.5"/>`);
 	}
 
 	if (hitAreas) {
 		const step = plotW / (last - first);
 		for (const s of history) {
-			parts.push(`<rect data-season="${s.season}" x="${(x(s.season) - step / 2).toFixed(1)}" y="0" width="${step.toFixed(1)}" height="${height}" fill="transparent" style="cursor:pointer"/>`);
+			parts.push(`<rect data-season="${s.season}" x="${(x(s.season) - step / 2).toFixed(1)}" y="${pad.t - (eras ? 0 : stripH)}" width="${step.toFixed(1)}" height="${height - pad.t}" fill="transparent" style="cursor:pointer"/>`);
+		}
+		if (eras) {
+			for (const era of eras) {
+				const from = Math.max(era.from - 0.5, first), to = Math.min(era.to + 0.5, last);
+				if (to < from || !era.key) continue;
+				parts.push(`<rect data-era="${era.key}" x="${x(from).toFixed(1)}" y="${pad.t - stripH}" width="${(x(to) - x(from)).toFixed(1)}" height="${stripH}" fill="transparent" style="cursor:pointer"/>`);
+			}
 		}
 	}
 

--- a/history.html
+++ b/history.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Packers Season-by-Season History</title>
+    <meta name="description" content="Every Green Bay Packers season since 1921 in one chart.">
+    <meta property="og:title" content="Packers Season-by-Season History">
+    <meta property="og:description" content="Every Green Bay Packers season since 1921 in one chart.">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
+    <!-- Absolute asset paths: this shell is also reachable at /history/, where relative paths would break. -->
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="container records-container">
+        <a href="/" class="records-back"><i class="mdi mdi-arrow-left"></i> Are the Packers Undefeated?</a>
+        <h1 class="records-title">Franchise History</h1>
+        <p id="history-subtitle" class="records-subtitle"></p>
+        <div class="history-controls">
+            <div class="history-toggle" role="group" aria-label="Chart metric">
+                <button id="metric-winpct" class="history-toggle-btn" aria-pressed="true">Win %</button>
+                <button id="metric-wins" class="history-toggle-btn" aria-pressed="false">Wins</button>
+            </div>
+        </div>
+        <div id="history-chart" class="history-chart">
+            <div class="loading">Loading history...</div>
+        </div>
+        <div id="history-tooltip" class="history-tooltip" hidden></div>
+        <p class="history-legend">
+            <span class="history-legend-item"><span class="legend-dot legend-champ"></span> Championship season</span>
+            <span class="history-legend-item"><span class="legend-dot legend-perfect"></span> Perfect season</span>
+            <span class="history-legend-item">Click any season to open it</span>
+        </p>
+        <div class="record-share" id="history-share"></div>
+    </div>
+
+    <footer class="site-footer">
+        <a href="https://github.com/rptetzloff/AreThePackersUndefeated" target="_blank" rel="noopener noreferrer" class="github-link">
+            <i class="mdi mdi-github"></i>
+            View on GitHub
+        </a>
+    </footer>
+
+    <script src="/history.js" type="module"></script>
+</body>
+</html>

--- a/history.html
+++ b/history.html
@@ -19,10 +19,13 @@
         <h1 class="records-title">Franchise History</h1>
         <p id="history-subtitle" class="records-subtitle"></p>
         <div class="history-controls">
-            <div class="history-toggle" role="group" aria-label="Chart metric">
-                <button id="metric-winpct" class="history-toggle-btn" aria-pressed="true">Win %</button>
-                <button id="metric-wins" class="history-toggle-btn" aria-pressed="false">Wins</button>
+            <div id="history-metrics" class="history-toggle" role="group" aria-label="Chart metrics (choose any)">
+                <button data-metric="winPct" class="history-toggle-btn">Win %</button>
+                <button data-metric="wins" class="history-toggle-btn">Wins</button>
+                <button data-metric="pf" class="history-toggle-btn">Points For</button>
+                <button data-metric="pa" class="history-toggle-btn">Points Against</button>
             </div>
+            <label class="h2h-check"><input type="checkbox" id="history-playoffs"> Include playoffs</label>
         </div>
         <div id="history-chart" class="history-chart">
             <div class="loading">Loading history...</div>

--- a/history.html
+++ b/history.html
@@ -36,7 +36,7 @@
             <span class="history-legend-item"><span class="legend-dot legend-perfect"></span> Perfect season</span>
             <span class="history-legend-item">Click any season to open it</span>
         </p>
-        <div class="record-share" id="history-share"></div>
+        <div class="share-section" id="history-share"></div>
     </div>
 
     <footer class="site-footer">

--- a/history.js
+++ b/history.js
@@ -1,0 +1,85 @@
+// Franchise history page: one point per season since 1921, rendered from the
+// shared chart builder (history-chart.js) over the shared season computation
+// (records-core.js). Hover shows the record; click opens that season's page.
+import { parseGamesCsv, computeSeasonHistory, historyCopy } from './records-core.js';
+import { buildChartSvg, ERAS } from './history-chart.js';
+import { shareButtonsHtml, wireShareRow } from './share-core.js';
+
+const chartEl = document.getElementById('history-chart');
+const tooltip = document.getElementById('history-tooltip');
+
+function seasonLabel(s) {
+	const notes = [];
+	if (s.superbowl) notes.push('Super Bowl champions');
+	else if (s.champion) notes.push('NFL champions');
+	if (s.undefeated) notes.push('perfect season');
+	return `${s.season} · ${s.record}${notes.length ? ` · ${notes.join(', ')}` : ''}`;
+}
+
+function render(history, metric) {
+	chartEl.innerHTML = buildChartSvg(history, {
+		metric,
+		axes: true,
+		eras: ERAS,
+		hitAreas: true,
+		emoji: true,
+	});
+	const bySeason = new Map(history.map((s) => [s.season, s]));
+
+	chartEl.querySelectorAll('[data-season]').forEach((hit) => {
+		const s = bySeason.get(parseInt(hit.dataset.season, 10));
+		hit.addEventListener('mouseenter', () => {
+			tooltip.textContent = seasonLabel(s);
+			tooltip.hidden = false;
+		});
+		hit.addEventListener('mousemove', (e) => {
+			const box = chartEl.getBoundingClientRect();
+			tooltip.style.left = `${Math.min(e.clientX - box.left + 12, box.width - tooltip.offsetWidth - 4)}px`;
+			tooltip.style.top = `${e.clientY - box.top - 34}px`;
+		});
+		hit.addEventListener('mouseleave', () => { tooltip.hidden = true; });
+		hit.addEventListener('click', () => { window.location.href = `/${s.season}`; });
+	});
+}
+
+async function init() {
+	try {
+		const res = await fetch('/data/packers_games.csv');
+		if (!res.ok) throw new Error(`CSV fetch failed: ${res.status}`);
+		const history = computeSeasonHistory(parseGamesCsv(await res.text()));
+		const titles = history.filter((s) => s.champion).length;
+		document.getElementById('history-subtitle').textContent =
+			`Green Bay Packers · ${history[0].season}–${history[history.length - 1].season} · ${titles} championships`;
+
+		// Metric choice persists like the site's other settings.
+		let metric = localStorage.getItem('historyMetric') === 'wins' ? 'wins' : 'winPct';
+		const btns = {
+			winPct: document.getElementById('metric-winpct'),
+			wins: document.getElementById('metric-wins'),
+		};
+		const apply = () => {
+			for (const [key, btn] of Object.entries(btns)) {
+				btn.classList.toggle('history-toggle-active', key === metric);
+				btn.setAttribute('aria-pressed', String(key === metric));
+			}
+			render(history, metric);
+		};
+		for (const [key, btn] of Object.entries(btns)) {
+			btn.addEventListener('click', () => {
+				metric = key;
+				localStorage.setItem('historyMetric', metric);
+				apply();
+			});
+		}
+		apply();
+
+		const share = document.getElementById('history-share');
+		share.innerHTML = shareButtonsHtml('share-btn record-share-btn');
+		wireShareRow(share, historyCopy(history).desc, `${window.location.origin}/history`);
+	} catch (e) {
+		chartEl.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
+		console.error(e);
+	}
+}
+
+init();

--- a/history.js
+++ b/history.js
@@ -22,7 +22,7 @@ function seasonLabel(s) {
 }
 
 function coachLabel(c) {
-	const bits = [`${c.name} · ${c.tenure} · ${c.record} (${pct(c.winPct)})`];
+	const bits = [`${c.name}${c.interim ? ' (interim)' : ''} · ${c.tenure} · ${c.record} (${pct(c.winPct)})`];
 	if (c.playoffRecord) bits.push(`playoffs ${c.playoffRecord}`);
 	if (c.titles) bits.push(`${c.titles} title${c.titles === 1 ? '' : 's'}`);
 	return bits.join(' · ');
@@ -49,6 +49,11 @@ function render(history, coaches, metrics) {
 	chartEl.innerHTML = buildChartSvg(history, {
 		metrics, axes: true, eras, hitAreas: true, emoji: true,
 	});
+	// The tooltip must live INSIDE the position:relative chart container or
+	// its absolute coordinates resolve against the page, far from the cursor.
+	// innerHTML above wipes the container, so re-append after every render.
+	tooltip.hidden = true;
+	chartEl.appendChild(tooltip);
 	const bySeason = new Map(history.map((s) => [s.season, s]));
 	const coachBySlug = new Map(coaches.map((c) => [c.slug, c]));
 

--- a/history.js
+++ b/history.js
@@ -1,81 +1,131 @@
 // Franchise history page: one point per season since 1921, rendered from the
 // shared chart builder (history-chart.js) over the shared season computation
-// (records-core.js). Hover shows the record; click opens that season's page.
+// (records-core.js). Multiple metrics can be plotted at once, playoffs can be
+// folded in, coach-era strips carry each coach's record, hover shows a
+// season's numbers, and clicking a season opens its page.
 import { parseGamesCsv, computeSeasonHistory, historyCopy } from './records-core.js';
-import { buildChartSvg, ERAS } from './history-chart.js';
+import { parseCoachesCsv, computeCoaches } from './coaches-core.js';
+import { buildChartSvg, METRICS } from './history-chart.js';
 import { shareButtonsHtml, wireShareRow } from './share-core.js';
 
 const chartEl = document.getElementById('history-chart');
 const tooltip = document.getElementById('history-tooltip');
+
+const pct = (p) => (p >= 1 ? '1.000' : p.toFixed(3).replace(/^0/, ''));
 
 function seasonLabel(s) {
 	const notes = [];
 	if (s.superbowl) notes.push('Super Bowl champions');
 	else if (s.champion) notes.push('NFL champions');
 	if (s.undefeated) notes.push('perfect season');
-	return `${s.season} · ${s.record}${notes.length ? ` · ${notes.join(', ')}` : ''}`;
+	return `${s.season} · ${s.record} · PF ${s.pf} · PA ${s.pa}${notes.length ? ` · ${notes.join(', ')}` : ''}`;
 }
 
-function render(history, metric) {
+function coachLabel(c) {
+	const bits = [`${c.name} · ${c.tenure} · ${c.record} (${pct(c.winPct)})`];
+	if (c.playoffRecord) bits.push(`playoffs ${c.playoffRecord}`);
+	if (c.titles) bits.push(`${c.titles} title${c.titles === 1 ? '' : 's'}`);
+	return bits.join(' · ');
+}
+
+// "Curly Lambeau" -> "Lambeau", "Hugh Devore & Scooter McLean" -> "Devore/McLean"
+const bandLabel = (name) => name.split('&').map((p) => p.trim().split(' ').pop()).join('/');
+
+function showTooltip(text) {
+	tooltip.textContent = text;
+	tooltip.hidden = false;
+}
+
+function placeTooltip(e) {
+	const box = chartEl.getBoundingClientRect();
+	tooltip.style.left = `${Math.min(e.clientX - box.left + 12, box.width - tooltip.offsetWidth - 4)}px`;
+	tooltip.style.top = `${e.clientY - box.top - 34}px`;
+}
+
+function render(history, coaches, metrics) {
+	const eras = coaches.map((c) => ({
+		label: bandLabel(c.name), from: c.firstSeason, to: c.lastSeason, key: c.slug,
+	}));
 	chartEl.innerHTML = buildChartSvg(history, {
-		metric,
-		axes: true,
-		eras: ERAS,
-		hitAreas: true,
-		emoji: true,
+		metrics, axes: true, eras, hitAreas: true, emoji: true,
 	});
 	const bySeason = new Map(history.map((s) => [s.season, s]));
+	const coachBySlug = new Map(coaches.map((c) => [c.slug, c]));
 
 	chartEl.querySelectorAll('[data-season]').forEach((hit) => {
 		const s = bySeason.get(parseInt(hit.dataset.season, 10));
-		hit.addEventListener('mouseenter', () => {
-			tooltip.textContent = seasonLabel(s);
-			tooltip.hidden = false;
-		});
-		hit.addEventListener('mousemove', (e) => {
-			const box = chartEl.getBoundingClientRect();
-			tooltip.style.left = `${Math.min(e.clientX - box.left + 12, box.width - tooltip.offsetWidth - 4)}px`;
-			tooltip.style.top = `${e.clientY - box.top - 34}px`;
-		});
+		hit.addEventListener('mouseenter', () => showTooltip(seasonLabel(s)));
+		hit.addEventListener('mousemove', placeTooltip);
 		hit.addEventListener('mouseleave', () => { tooltip.hidden = true; });
 		hit.addEventListener('click', () => { window.location.href = `/${s.season}`; });
+	});
+	chartEl.querySelectorAll('[data-era]').forEach((strip) => {
+		const c = coachBySlug.get(strip.dataset.era);
+		strip.addEventListener('mouseenter', () => showTooltip(coachLabel(c)));
+		strip.addEventListener('mousemove', placeTooltip);
+		strip.addEventListener('mouseleave', () => { tooltip.hidden = true; });
+		strip.addEventListener('click', () => { window.location.href = '/coaches.html'; });
 	});
 }
 
 async function init() {
 	try {
-		const res = await fetch('/data/packers_games.csv');
-		if (!res.ok) throw new Error(`CSV fetch failed: ${res.status}`);
-		const history = computeSeasonHistory(parseGamesCsv(await res.text()));
-		const titles = history.filter((s) => s.champion).length;
-		document.getElementById('history-subtitle').textContent =
-			`Green Bay Packers · ${history[0].season}–${history[history.length - 1].season} · ${titles} championships`;
+		const [gamesRes, coachesRes] = await Promise.all([
+			fetch('/data/packers_games.csv'),
+			fetch('/data/packers_coaches.csv'),
+		]);
+		if (!gamesRes.ok || !coachesRes.ok) throw new Error('CSV fetch failed');
+		const rows = parseGamesCsv(await gamesRes.text());
+		const histories = {
+			regular: computeSeasonHistory(rows),
+			playoffs: computeSeasonHistory(rows, { playoffs: true }),
+		};
+		const champions = histories.regular.filter((s) => s.champion).map((s) => s.season);
+		const { coaches } = computeCoaches(rows, parseCoachesCsv(await coachesRes.text()), champions);
 
-		// Metric choice persists like the site's other settings.
-		let metric = localStorage.getItem('historyMetric') === 'wins' ? 'wins' : 'winPct';
-		const btns = {
-			winPct: document.getElementById('metric-winpct'),
-			wins: document.getElementById('metric-wins'),
-		};
+		const titles = histories.regular.filter((s) => s.champion).length;
+		const range = `${histories.regular[0].season}–${histories.regular[histories.regular.length - 1].season}`;
+		document.getElementById('history-subtitle').textContent =
+			`Green Bay Packers · ${range} · ${titles} championships · ${coaches.length} head coaches`;
+
+		// Metric selection and playoffs inclusion persist like other settings.
+		let metrics;
+		try { metrics = JSON.parse(localStorage.getItem('historyMetrics') || '[]'); } catch { metrics = []; }
+		metrics = metrics.filter((m) => METRICS[m]);
+		if (!metrics.length) metrics = ['winPct'];
+		const playoffsBox = document.getElementById('history-playoffs');
+		playoffsBox.checked = localStorage.getItem('historyPlayoffs') === 'true';
+
+		const chips = [...document.querySelectorAll('#history-metrics [data-metric]')];
 		const apply = () => {
-			for (const [key, btn] of Object.entries(btns)) {
-				btn.classList.toggle('history-toggle-active', key === metric);
-				btn.setAttribute('aria-pressed', String(key === metric));
+			for (const chip of chips) {
+				const key = chip.dataset.metric;
+				const on = metrics.includes(key);
+				chip.classList.toggle('history-toggle-active', on);
+				chip.setAttribute('aria-pressed', String(on));
+				chip.style.color = on ? METRICS[key].color : '';
 			}
-			render(history, metric);
+			render(histories[playoffsBox.checked ? 'playoffs' : 'regular'], coaches, metrics);
 		};
-		for (const [key, btn] of Object.entries(btns)) {
-			btn.addEventListener('click', () => {
-				metric = key;
-				localStorage.setItem('historyMetric', metric);
+		for (const chip of chips) {
+			chip.addEventListener('click', () => {
+				const key = chip.dataset.metric;
+				metrics = metrics.includes(key) ? metrics.filter((m) => m !== key) : [...metrics, key];
+				if (!metrics.length) metrics = [key]; // at least one metric stays on
+				metrics.sort((a, b) => Object.keys(METRICS).indexOf(a) - Object.keys(METRICS).indexOf(b));
+				localStorage.setItem('historyMetrics', JSON.stringify(metrics));
 				apply();
 			});
 		}
+		playoffsBox.addEventListener('change', () => {
+			localStorage.setItem('historyPlayoffs', String(playoffsBox.checked));
+			apply();
+		});
 		apply();
 
 		const share = document.getElementById('history-share');
 		share.innerHTML = shareButtonsHtml('share-btn record-share-btn');
-		wireShareRow(share, historyCopy(history).desc, `${window.location.origin}/history`);
+		wireShareRow(share, historyCopy(histories.regular).desc, `${window.location.origin}/history`);
 	} catch (e) {
 		chartEl.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
 		console.error(e);

--- a/history.js
+++ b/history.js
@@ -129,8 +129,8 @@ async function init() {
 		apply();
 
 		const share = document.getElementById('history-share');
-		share.innerHTML = shareButtonsHtml('share-btn record-share-btn');
-		wireShareRow(share, historyCopy(histories.regular).desc, `${window.location.origin}/history`);
+		share.innerHTML = shareButtonsHtml('share-btn', { labels: true });
+		wireShareRow(share, historyCopy(histories.regular).desc, `${window.location.origin}/history`, { labels: true });
 	} catch (e) {
 		chartEl.innerHTML = '<p class="record-empty">Could not load the game data. Try again later.</p>';
 		console.error(e);

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <h1 id="site-title" class="site-title">Are the Packers Undefeated?</h1>
         <div id="answer" class="answer loading">Loading...</div>
         <div id="record" class="record"></div>
+        <a id="history-spark" class="history-spark" href="/history.html" aria-label="Franchise history, season by season" title="Franchise history, season by season"></a>
         <details id="streak-details" class="collapsible-section" open>
             <summary class="collapsible-summary">Streak</summary>
             <div id="streak-banner" class="streak-banner" hidden></div>
@@ -57,6 +58,7 @@
         <!-- .html links work under both server.js (meta-injected, clean canonical) and static dev servers -->
         <a href="/records.html" class="share-btn records-link"><i class="mdi mdi-trophy-outline"></i> Records &amp; Superlatives</a>
         <a href="/vs.html" class="share-btn records-link"><i class="mdi mdi-sword-cross"></i> Head-to-Head</a>
+        <a href="/history.html" class="share-btn records-link"><i class="mdi mdi-chart-line"></i> History</a>
 
         <div class="share-section">
             <button id="share-native" class="share-btn" hidden>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
         <a href="/records.html" class="share-btn records-link"><i class="mdi mdi-trophy-outline"></i> Records &amp; Superlatives</a>
         <a href="/vs.html" class="share-btn records-link"><i class="mdi mdi-sword-cross"></i> Head-to-Head</a>
         <a href="/history.html" class="share-btn records-link"><i class="mdi mdi-chart-line"></i> History</a>
+        <a href="/coaches.html" class="share-btn records-link"><i class="mdi mdi-whistle-outline"></i> Coaches</a>
 
         <div class="share-section">
             <button id="share-native" class="share-btn" hidden>

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -287,3 +287,25 @@ export function buildHistorySvg(history) {
 export function renderHistoryPng(history) {
   return toPng(buildHistorySvg(history));
 }
+
+// --- Head coaches card ---
+
+export function buildCoachesSvg(data) {
+  const { coaches } = data;
+  const mostWins = [...coaches].sort((a, b) => b.wins - a.wins)[0];
+  const bestPct = [...coaches].filter((c) => c.games >= 40).sort((a, b) => b.winPct - a.winPct)[0];
+  const titles = coaches.reduce((s, c) => s + c.titles, 0);
+  return recordsFrame({
+    heading: 'HEAD COACHES', range: `${coaches[0].firstSeason}–present`,
+    big: String(coaches.length),
+    context: `head coaches · ${titles} championships between them`,
+    runners: [
+      `most wins: ${mostWins.name} — ${mostWins.record}`,
+      `best win %: ${bestPct.name} — ${bestPct.record} (min. 40 games)`,
+    ],
+  });
+}
+
+export function renderCoachesPng(data) {
+  return toPng(buildCoachesSvg(data));
+}

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -7,6 +7,7 @@ import { Resvg } from '@resvg/resvg-js';
 import * as OT from 'opentype.js';
 import { formatDate, streakSpan, esc } from '../records-core.js';
 import { meetings } from '../h2h-core.js';
+import { buildChartSvg } from '../history-chart.js';
 
 const opentype = OT.default ?? OT;
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -261,4 +262,28 @@ export function buildH2hSvg(slug, data) {
 
 export function renderH2hPng(slug, data) {
   return toPng(buildH2hSvg(slug, data));
+}
+
+// --- Franchise-history card: the actual chart, one point per season ---
+
+export function buildHistorySvg(history) {
+  const first = history[0].season, last = history[history.length - 1].season;
+  const titles = history.filter((s) => s.champion).length;
+  const winning = history.filter((s) => s.winPct > 0.5).length;
+  // Nested SVG: the shared chart builder renders the same geometry the site
+  // shows, scaled into the card frame. No emoji — the PNG fonts lack them.
+  const chart = buildChartSvg(history, {
+    width: 1060, height: 300,
+    axes: false, markers: true, emoji: false,
+  }).replace('<svg ', '<svg x="70" y="200" ');
+  return frame(
+    title('A CENTURY IN GREEN & GOLD', 54)
+    + sub(168, `Green Bay Packers · every season, ${first}–${last}`)
+    + chart
+    + line(548, `${titles} championships · ${winning} winning seasons · ${history.length} years`, WHITE, 30)
+  );
+}
+
+export function renderHistoryPng(history) {
+  return toPng(buildHistorySvg(history));
 }

--- a/lib/cards.js
+++ b/lib/cards.js
@@ -297,7 +297,7 @@ export function buildCoachesSvg(data) {
   const titles = coaches.reduce((s, c) => s + c.titles, 0);
   return recordsFrame({
     heading: 'HEAD COACHES', range: `${coaches[0].firstSeason}–present`,
-    big: String(coaches.length),
+    big: String(coaches.filter((c) => !c.interim).length),
     context: `head coaches · ${titles} championships between them`,
     runners: [
       `most wins: ${mostWins.name} — ${mostWins.record}`,

--- a/lib/coaches.js
+++ b/lib/coaches.js
@@ -1,0 +1,19 @@
+// Server-side head coaches: computed once at startup from the same parsed
+// rows lib/seasons.js loads plus data/packers_coaches.csv. Pure computation
+// lives in coaches-core.js (shared with the browser page).
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { parseCoachesCsv, computeCoaches, coachesCopy } from '../coaches-core.js';
+import { allGames } from './seasons.js';
+import { seasonHistory } from './records.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CSV = join(__dirname, '..', 'data', 'packers_coaches.csv');
+
+const champions = seasonHistory.filter((s) => s.champion).map((s) => s.season);
+export const coaches = computeCoaches(allGames, parseCoachesCsv(readFileSync(CSV, 'utf8')), champions);
+
+export function coachesMeta() {
+	return coachesCopy(coaches);
+}

--- a/lib/records.js
+++ b/lib/records.js
@@ -1,10 +1,15 @@
 // Server-side records/superlatives: computed once at startup from the same
 // parsed CSV rows lib/seasons.js loads. Pure computation lives in
 // records-core.js (shared with the browser page).
-import { computeSuperlatives, recordsCopy, RECORD_SLUGS } from '../records-core.js';
+import { computeSuperlatives, computeSeasonHistory, recordsCopy, historyCopy, RECORD_SLUGS } from '../records-core.js';
 import { allGames } from './seasons.js';
 
 export const records = computeSuperlatives(allGames);
+export const seasonHistory = computeSeasonHistory(allGames);
+
+export function historyMeta() {
+	return historyCopy(seasonHistory);
+}
 
 export function isRecordSlug(slug) {
 	return RECORD_SLUGS.includes(slug);

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
-        import { parseGamesCsv } from './records-core.js';
+        import { parseGamesCsv, computeSeasonHistory } from './records-core.js';
         import { computeHeadToHead, canonicalOpponent } from './h2h-core.js';
+        import { buildChartSvg } from './history-chart.js';
         import { intentUrls, copyText, flashCopied } from './share-core.js';
 
         function buildSeasonMap(games) {
@@ -62,6 +63,8 @@
         				this.csvBySeason = buildSeasonMap(games);
         				// name -> all-time head-to-head entry, for schedule annotations
         				this.h2hByName = new Map(computeHeadToHead(games).opponents.map(o => [o.name, o]));
+        				this.seasonHistory = computeSeasonHistory(games);
+        				this.renderHistorySpark();
         				const seasons = Object.keys(this.csvBySeason).map(Number).sort((a, b) => a - b);
         				if (seasons.length) {
         					this.earliestSeason = seasons[0];
@@ -145,8 +148,21 @@
           el.textContent = `${past ? 'Were' : 'Are'} the Packers Undefeated?`;
       }
 
+      // Compact franchise-history sparkline under the answer; the currently
+      // viewed season gets a white marker. Links through to /history.
+      renderHistorySpark() {
+          const el = document.getElementById('history-spark');
+          if (!el || !this.seasonHistory?.length) return;
+          el.innerHTML = buildChartSvg(this.seasonHistory, {
+              width: 600, height: 80,
+              axes: false,
+              highlight: this.currentSeason,
+          });
+      }
+
       updateSeasonSelector() {
           this.updateSiteTitle();
+          this.renderHistorySpark();
           const label = document.getElementById('season-label');
           const prevBtn = document.getElementById('season-prev');
           const nextBtn = document.getElementById('season-next');

--- a/main.js
+++ b/main.js
@@ -145,7 +145,9 @@
           const el = document.getElementById('site-title');
           if (!el) return;
           const past = this.currentSeason && this.latestSeason && this.currentSeason < this.latestSeason;
-          el.textContent = `${past ? 'Were' : 'Are'} the Packers Undefeated?`;
+          el.textContent = past
+              ? `Were the Packers Undefeated in ${this.currentSeason}?`
+              : 'Are the Packers Undefeated?';
       }
 
       // Compact franchise-history sparkline under the answer; the currently

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-        import { parseGamesCsv, computeSeasonHistory } from './records-core.js';
+        import { parseGamesCsv, computeSeasonHistory, localDate } from './records-core.js';
         import { computeHeadToHead, canonicalOpponent } from './h2h-core.js';
         import { buildChartSvg } from './history-chart.js';
         import { intentUrls, copyText, flashCopied } from './share-core.js';
@@ -384,7 +384,7 @@ createCsvGameItem(g, showH2h = false) {
         		const location = g.location; // HOME / AWAY / NEUTRAL
         		const packersScore = parseInt(g.packers_score) || 0;
         		const opponentScore = parseInt(g.opponent_score) || 0;
-        		const date = new Date(g.date);
+        		const date = localDate(g.date);
         		const isSuperBowl = g.superbowl && g.superbowl.trim() !== '';
 
         		const gameItem = document.createElement('div');
@@ -1126,7 +1126,7 @@ buildOnThisDay() {
   if (!el) return;
 
   const dateParam = new URLSearchParams(window.location.search).get('otd');
-  const today = dateParam ? new Date(`2000-${dateParam}`) : new Date();
+  const today = dateParam ? localDate(`2000-${dateParam}`) : new Date();
   const todayMonth = isNaN(today) ? new Date().getMonth() : today.getMonth();
   const todayDay = isNaN(today) ? new Date().getDate() : today.getDate();
 
@@ -1134,7 +1134,7 @@ buildOnThisDay() {
   for (const [yr, games] of Object.entries(this.csvBySeason)) {
      for (const g of games) {
         if (!g.date) continue;
-        const d = new Date(g.date);
+        const d = localDate(g.date);
         if (isNaN(d)) continue;
         const diff = Math.abs((d.getMonth() * 31 + d.getDate()) - (todayMonth * 31 + todayDay));
         if (diff <= 3) candidates.push({ game: g, season: parseInt(yr), date: d });

--- a/records-core.js
+++ b/records-core.js
@@ -149,6 +149,62 @@ export function computeSuperlatives(rows, { top = 5, now = new Date() } = {}) {
 export const streakSpan = (s) =>
 	s.startSeason === s.endSeason ? String(s.startSeason) : `${s.startSeason}–${s.endSeason}`;
 
+// The 1929-31 titles were awarded on standings — no championship game to win.
+// Every later title (NFL Championships and Super Bowls) is "won the season's
+// final playoff game".
+const STANDINGS_TITLES = new Set([1929, 1930, 1931]);
+
+// One entry per season, chronological: regular-season record and win% (ties
+// count half), plus championship/undefeated flags for chart markers.
+export function computeSeasonHistory(rows, { now = new Date() } = {}) {
+	const games = rows
+		.filter((r) => ['WIN', 'LOSS', 'TIE'].includes(r['Packers Win']))
+		.slice()
+		.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+	const bySeason = new Map();
+	for (const g of games) {
+		const yr = parseInt(g.season, 10);
+		if (!bySeason.has(yr)) bySeason.set(yr, []);
+		bySeason.get(yr).push(g);
+	}
+	return [...bySeason.keys()].sort((a, b) => a - b).map((yr) => {
+		let w = 0, l = 0, t = 0;
+		let lastPlayoff = null;
+		let superbowl = false;
+		for (const g of bySeason.get(yr)) {
+			if (g.regular_season === '1') {
+				if (g['Packers Win'] === 'WIN') w++;
+				else if (g['Packers Win'] === 'LOSS') l++;
+				else t++;
+			} else {
+				lastPlayoff = g;
+				if (g.superbowl && g.superbowl.trim() && g['Packers Win'] === 'WIN') superbowl = true;
+			}
+		}
+		const gamesPlayed = w + l + t;
+		return {
+			season: yr,
+			wins: w, losses: l, ties: t,
+			record: rec(w, l, t),
+			winPct: gamesPlayed ? (w + t / 2) / gamesPlayed : 0,
+			champion: STANDINGS_TITLES.has(yr) || (lastPlayoff !== null && lastPlayoff['Packers Win'] === 'WIN'),
+			superbowl,
+			undefeated: l === 0 && w > 0 && seasonSettled(yr, now),
+		};
+	});
+}
+
+// Meta copy for the /history page, shared by server OG meta and client share.
+export function historyCopy(history) {
+	const first = history[0].season, last = history[history.length - 1].season;
+	const titles = history.filter((s) => s.champion).length;
+	const winning = history.filter((s) => s.winPct > 0.5).length;
+	return {
+		title: `Packers Season-by-Season History, ${first}–${last}`,
+		desc: `Every Green Bay Packers season since ${first} in one chart: ${titles} championships and ${winning} winning seasons across ${history.length} years.`,
+	};
+}
+
 // Per-card copy shared by server OG meta and client share messages.
 // slug 'overview' covers the /records landing URL.
 export function recordsCopy(slug, data) {

--- a/records-core.js
+++ b/records-core.js
@@ -154,9 +154,11 @@ export const streakSpan = (s) =>
 // final playoff game".
 const STANDINGS_TITLES = new Set([1929, 1930, 1931]);
 
-// One entry per season, chronological: regular-season record and win% (ties
-// count half), plus championship/undefeated flags for chart markers.
-export function computeSeasonHistory(rows, { now = new Date() } = {}) {
+// One entry per season, chronological: record, win% (ties count half), and
+// points for/against, plus championship/undefeated flags for chart markers.
+// `playoffs: true` folds postseason games into the record/points; the
+// champion and undefeated flags always use their own rules regardless.
+export function computeSeasonHistory(rows, { now = new Date(), playoffs = false } = {}) {
 	const games = rows
 		.filter((r) => ['WIN', 'LOSS', 'TIE'].includes(r['Packers Win']))
 		.slice()
@@ -168,18 +170,25 @@ export function computeSeasonHistory(rows, { now = new Date() } = {}) {
 		bySeason.get(yr).push(g);
 	}
 	return [...bySeason.keys()].sort((a, b) => a - b).map((yr) => {
-		let w = 0, l = 0, t = 0;
+		let w = 0, l = 0, t = 0, pf = 0, pa = 0, regLosses = 0, regWins = 0;
 		let lastPlayoff = null;
 		let superbowl = false;
 		for (const g of bySeason.get(yr)) {
-			if (g.regular_season === '1') {
-				if (g['Packers Win'] === 'WIN') w++;
-				else if (g['Packers Win'] === 'LOSS') l++;
-				else t++;
-			} else {
+			const isReg = g.regular_season === '1';
+			if (!isReg) {
 				lastPlayoff = g;
 				if (g.superbowl && g.superbowl.trim() && g['Packers Win'] === 'WIN') superbowl = true;
 			}
+			if (isReg) {
+				if (g['Packers Win'] === 'WIN') regWins++;
+				else if (g['Packers Win'] === 'LOSS') regLosses++;
+			}
+			if (!isReg && !playoffs) continue;
+			if (g['Packers Win'] === 'WIN') w++;
+			else if (g['Packers Win'] === 'LOSS') l++;
+			else t++;
+			pf += parseInt(g.packers_score, 10) || 0;
+			pa += parseInt(g.opponent_score, 10) || 0;
 		}
 		const gamesPlayed = w + l + t;
 		return {
@@ -187,9 +196,10 @@ export function computeSeasonHistory(rows, { now = new Date() } = {}) {
 			wins: w, losses: l, ties: t,
 			record: rec(w, l, t),
 			winPct: gamesPlayed ? (w + t / 2) / gamesPlayed : 0,
+			pf, pa,
 			champion: STANDINGS_TITLES.has(yr) || (lastPlayoff !== null && lastPlayoff['Packers Win'] === 'WIN'),
 			superbowl,
-			undefeated: l === 0 && w > 0 && seasonSettled(yr, now),
+			undefeated: regLosses === 0 && regWins > 0 && seasonSettled(yr, now),
 		};
 	});
 }

--- a/records-core.js
+++ b/records-core.js
@@ -31,6 +31,14 @@ export function formatDate(iso) {
 	return `${MONTHS[m - 1]} ${d}, ${y}`;
 }
 
+// 'YYYY-MM-DD' -> local-time Date. new Date('YYYY-MM-DD') parses as UTC
+// midnight, which any timezone west of UTC displays as the PREVIOUS day
+// (Sunday games labelled Saturday).
+export function localDate(iso) {
+	const [y, m, d] = iso.split('-').map((n) => parseInt(n, 10));
+	return new Date(y, m - 1, d);
+}
+
 export const rec = (w, l, t) => (t > 0 ? `${w}–${l}–${t}` : `${w}–${l}`);
 
 export const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');

--- a/server.js
+++ b/server.js
@@ -8,9 +8,9 @@ import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, extname } from 'node:path';
-import { renderPng, renderRecordsPng, renderH2hPng } from './lib/cards.js';
+import { renderPng, renderRecordsPng, renderH2hPng, renderHistoryPng } from './lib/cards.js';
 import { getSeasonState, defaultSeason } from './lib/seasons.js';
-import { records, recordsMeta, isRecordSlug } from './lib/records.js';
+import { records, recordsMeta, isRecordSlug, seasonHistory, historyMeta } from './lib/records.js';
 import { h2h, h2hMeta, isOpponentSlug } from './lib/h2h.js';
 import { esc } from './records-core.js';
 
@@ -50,6 +50,7 @@ function loadShell(file, assets) {
 const INDEX_VERSIONED = loadShell('index.html', ['main.js', 'styles.css']);
 const RECORDS_VERSIONED = loadShell('records.html', ['records.js', 'styles.css']);
 const VS_VERSIONED = loadShell('vs.html', ['vs.js', 'styles.css']);
+const HISTORY_VERSIONED = loadShell('history.html', ['history.js', 'styles.css']);
 
 const MIME = {
   '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
@@ -254,6 +255,16 @@ const server = http.createServer(async (req, res) => {
       if (!isRecordSlug(slug)) return notFound(res);
       return serveRecordsHtml(req, res, slug);
     }
+
+    if (pathname === '/history' || pathname === '/history/' || pathname === '/history.html') {
+      const origin = originOf(req);
+      const { title, desc } = historyMeta();
+      return sendPage(res, HISTORY_VERSIONED, {
+        title, desc, img: `${origin}/og/history.png`, canonical: `${origin}/history`,
+      });
+    }
+    if (pathname === '/og/history.png')
+      return serveCachedPng(res, 'history', () => renderHistoryPng(seasonHistory));
 
     if (pathname === '/vs' || pathname === '/vs/' || pathname === '/vs.html')
       return serveVsHtml(req, res, undefined);

--- a/server.js
+++ b/server.js
@@ -8,9 +8,10 @@ import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, extname } from 'node:path';
-import { renderPng, renderRecordsPng, renderH2hPng, renderHistoryPng } from './lib/cards.js';
+import { renderPng, renderRecordsPng, renderH2hPng, renderHistoryPng, renderCoachesPng } from './lib/cards.js';
 import { getSeasonState, defaultSeason } from './lib/seasons.js';
 import { records, recordsMeta, isRecordSlug, seasonHistory, historyMeta } from './lib/records.js';
+import { coaches, coachesMeta } from './lib/coaches.js';
 import { h2h, h2hMeta, isOpponentSlug } from './lib/h2h.js';
 import { esc } from './records-core.js';
 
@@ -51,6 +52,7 @@ const INDEX_VERSIONED = loadShell('index.html', ['main.js', 'styles.css']);
 const RECORDS_VERSIONED = loadShell('records.html', ['records.js', 'styles.css']);
 const VS_VERSIONED = loadShell('vs.html', ['vs.js', 'styles.css']);
 const HISTORY_VERSIONED = loadShell('history.html', ['history.js', 'styles.css']);
+const COACHES_VERSIONED = loadShell('coaches.html', ['coaches.js', 'styles.css']);
 
 const MIME = {
   '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
@@ -265,6 +267,16 @@ const server = http.createServer(async (req, res) => {
     }
     if (pathname === '/og/history.png')
       return serveCachedPng(res, 'history', () => renderHistoryPng(seasonHistory));
+
+    if (pathname === '/coaches' || pathname === '/coaches/' || pathname === '/coaches.html') {
+      const origin = originOf(req);
+      const { title, desc } = coachesMeta();
+      return sendPage(res, COACHES_VERSIONED, {
+        title, desc, img: `${origin}/og/coaches.png`, canonical: `${origin}/coaches`,
+      });
+    }
+    if (pathname === '/og/coaches.png')
+      return serveCachedPng(res, 'coaches', () => renderCoachesPng(coaches));
 
     if (pathname === '/vs' || pathname === '/vs/' || pathname === '/vs.html')
       return serveVsHtml(req, res, undefined);

--- a/server.js
+++ b/server.js
@@ -195,10 +195,11 @@ async function serveStatic(req, res, pathname) {
     const versioned = /[?&]v=/.test(req.url);
     const ext = extname(file).toLowerCase();
     // Unversioned JS (module imports like records-core.js can't carry ?v=)
-    // must revalidate on every load, or a deploy can pair a fresh versioned
-    // entry module with an hour-stale dependency.
+    // and the data CSVs (whose column shape must match the deployed code)
+    // must revalidate on every load, or a deploy can pair fresh code with
+    // hour-stale data/modules.
     const cache = versioned ? 'public, max-age=31536000, immutable'
-      : ext === '.js' ? 'no-cache'
+      : ext === '.js' || ext === '.csv' ? 'no-cache'
       : 'public, max-age=3600';
     res.writeHead(200, {
       'Content-Type': MIME[ext] || 'application/octet-stream',

--- a/share-core.js
+++ b/share-core.js
@@ -11,23 +11,30 @@ export function intentUrls(message, url) {
 	};
 }
 
-// Icon-only share buttons for a compact per-card share row: native share when
-// supported, otherwise the per-platform intent links, plus copy. Pair with
-// wireShareRow() after inserting into the DOM.
-export function shareButtonsHtml(btnClass) {
+// Share buttons: native share when supported, otherwise the per-platform
+// intent links, plus copy. Two formats — icon-only (compact, inside cards)
+// and labelled (page-level rows, matching the main page's share section).
+// Pair with wireShareRow() after inserting into the DOM.
+const SHARE_DEFS = [
+	['x', 'mdi-twitter', 'Post on X'],
+	['bsky', 'mdi-butterfly', 'Post on Bluesky'],
+	['fb', 'mdi-facebook', 'Share on Facebook'],
+	['reddit', 'mdi-reddit', 'Post on Reddit'],
+];
+
+export function shareButtonsHtml(btnClass, { labels = false } = {}) {
 	const native = !!navigator.share;
-	const alts = native ? '' : `
-		<a class="${btnClass}" data-share="x" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on X"><i class="mdi mdi-twitter"></i></a>
-		<a class="${btnClass}" data-share="bsky" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Bluesky"><i class="mdi mdi-butterfly"></i></a>
-		<a class="${btnClass}" data-share="fb" href="#" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook"><i class="mdi mdi-facebook"></i></a>
-		<a class="${btnClass}" data-share="reddit" href="#" target="_blank" rel="noopener noreferrer" aria-label="Post on Reddit"><i class="mdi mdi-reddit"></i></a>`;
-	return `${native ? `<button class="${btnClass}" data-share="native" aria-label="Share"><i class="mdi mdi-share-variant"></i></button>` : ''}
+	const text = (label) => (labels ? label : '');
+	const alts = native ? '' : SHARE_DEFS.map(([key, icon, label]) =>
+		`<a class="${btnClass}" data-share="${key}" href="#" target="_blank" rel="noopener noreferrer" aria-label="${label}"><i class="mdi ${icon} share-icon"></i>${text(label)}</a>`
+	).join('\n\t\t');
+	return `${native ? `<button class="${btnClass}" data-share="native" aria-label="Share"><i class="mdi mdi-share-variant share-icon"></i>${text('Share')}</button>` : ''}
 		${alts}
-		<button class="${btnClass}" data-share="copy" aria-label="Copy link"><i class="mdi mdi-clipboard-outline"></i></button>`;
+		<button class="${btnClass}" data-share="copy" aria-label="Copy link"><i class="mdi mdi-clipboard-outline share-icon"></i>${text('Copy')}</button>`;
 }
 
 // Wire the [data-share] buttons inside `row` to share `message` + `url`.
-export function wireShareRow(row, message, url) {
+export function wireShareRow(row, message, url, { labels = false } = {}) {
 	const links = intentUrls(message, url);
 	row.querySelectorAll('[data-share]').forEach((btn) => {
 		switch (btn.dataset.share) {
@@ -42,7 +49,9 @@ export function wireShareRow(row, message, url) {
 				break;
 			case 'copy':
 				btn.addEventListener('click', () => {
-					flashCopied(btn, '<i class="mdi mdi-check"></i>');
+					flashCopied(btn, labels
+						? '<i class="mdi mdi-check share-icon"></i>Copied!'
+						: '<i class="mdi mdi-check"></i>');
 					copyText(`${message}\n\n${url}`);
 				});
 				break;

--- a/sortable.js
+++ b/sortable.js
@@ -1,0 +1,34 @@
+// Minimal click-to-sort for tables rendered from an items array. Pages keep a
+// { key, dir } state object, sort their items with sortItems() inside their
+// render function, and call wireSortHeaders() after each render. Headers opt
+// in with data-sort="<item property>"; data-dir sets the first-click
+// direction (default desc — numbers usually want biggest-first).
+
+export function sortItems(items, state) {
+	if (!state.key) return items;
+	const dir = state.dir === 'asc' ? 1 : -1;
+	return [...items].sort((a, b) => {
+		const av = a[state.key], bv = b[state.key];
+		if (typeof av === 'string' || typeof bv === 'string') {
+			return String(av ?? '').localeCompare(String(bv ?? '')) * dir;
+		}
+		return ((av ?? -Infinity) - (bv ?? -Infinity)) * dir;
+	});
+}
+
+export function wireSortHeaders(container, state, rerender) {
+	container.querySelectorAll('th[data-sort]').forEach((th) => {
+		const key = th.dataset.sort;
+		th.classList.add('sortable');
+		if (state.key === key) th.classList.add(state.dir === 'asc' ? 'sorted-asc' : 'sorted-desc');
+		th.addEventListener('click', () => {
+			if (state.key === key) {
+				state.dir = state.dir === 'asc' ? 'desc' : 'asc';
+			} else {
+				state.key = key;
+				state.dir = th.dataset.dir || 'desc';
+			}
+			rerender();
+		});
+	});
+}

--- a/styles.css
+++ b/styles.css
@@ -1641,3 +1641,42 @@ details:not([open]) > .collapsible-summary::before {
 #history-share {
     justify-content: center;
 }
+
+
+/* --- Coach photos & interim markers --- */
+
+.coach-photo-cell {
+    width: 44px;
+}
+
+.coach-photo {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+    border: 1.5px solid rgba(255, 182, 18, 0.5);
+}
+
+.coach-photo-none {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 1.1rem;
+}
+
+.coach-interim {
+    color: #ffb612;
+    margin-left: 0.15rem;
+}
+
+@media (max-width: 600px) {
+    .coaches-table .coach-photo-cell {
+        display: none;
+    }
+    .coaches-table thead th:first-child {
+        display: none;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1549,6 +1549,9 @@ details:not([open]) > .collapsible-summary::before {
 .history-controls {
     display: flex;
     justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
     margin-bottom: 0.75rem;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1524,3 +1524,117 @@ details:not([open]) > .collapsible-summary::before {
         max-width: 100%;
     }
 }
+
+
+/* --- Franchise history --- */
+
+.history-spark {
+    display: block;
+    max-width: 600px;
+    margin: 0.25rem auto 0.5rem;
+    opacity: 0.9;
+    transition: opacity 0.2s;
+}
+
+.history-spark:hover {
+    opacity: 1;
+}
+
+.history-spark svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.history-controls {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 0.75rem;
+}
+
+.history-toggle {
+    display: inline-flex;
+    border: 1.5px solid rgba(255, 182, 18, 0.5);
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.history-toggle-btn {
+    padding: 0.4rem 1.1rem;
+    background: transparent;
+    border: none;
+    color: #ffb612;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+}
+
+.history-toggle-btn.history-toggle-active {
+    background: rgba(255, 182, 18, 0.25);
+    color: white;
+}
+
+.history-chart {
+    position: relative;
+    background: rgba(32, 55, 49, 0.8);
+    border: 2px solid #ffb612;
+    border-radius: 10px;
+    padding: 0.75rem;
+}
+
+.history-chart svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.history-tooltip {
+    position: absolute;
+    pointer-events: none;
+    background: #152A1E;
+    border: 1px solid #ffb612;
+    border-radius: 6px;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.85rem;
+    color: white;
+    white-space: nowrap;
+    z-index: 5;
+}
+
+.history-legend {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.85rem;
+    margin: 0.75rem 0 1rem;
+}
+
+.history-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.legend-champ {
+    background: #ffb612;
+    border: 1.5px solid #152A1E;
+}
+
+.legend-perfect {
+    background: transparent;
+    border: 1.5px solid white;
+}
+
+#history-share {
+    justify-content: center;
+}

--- a/styles.css
+++ b/styles.css
@@ -1638,8 +1638,23 @@ details:not([open]) > .collapsible-summary::before {
     border: 1.5px solid white;
 }
 
-#history-share {
-    justify-content: center;
+/* th sort affordances for sortable tables (see sortable.js) */
+th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+th.sortable:hover {
+    color: #ffd050;
+}
+
+th.sorted-asc::after {
+    content: ' \25B4';
+}
+
+th.sorted-desc::after {
+    content: ' \25BE';
 }
 
 

--- a/vs.js
+++ b/vs.js
@@ -4,6 +4,7 @@
 import { parseGamesCsv, formatDate, esc } from './records-core.js';
 import { computeHeadToHead, h2hCopy, streakSentence } from './h2h-core.js';
 import { shareButtonsHtml, wireShareRow } from './share-core.js';
+import { sortItems, wireSortHeaders } from './sortable.js';
 
 // Standard sports-page winning percentage: ties count half. ".622" / "1.000".
 const pct = (p) => (p >= 1 ? '1.000' : p.toFixed(3).replace(/^0/, ''));
@@ -38,7 +39,12 @@ function tableHtml(opponents) {
 			<td class="h2h-num">${pct(o.winPct)}</td>
 		</tr>`).join('');
 	return `<table class="h2h-table">
-		<thead><tr><th>Opponent</th><th class="h2h-num">Record</th><th class="h2h-num">Games</th><th class="h2h-num">Win %</th></tr></thead>
+		<thead><tr>
+			<th data-sort="name" data-dir="asc">Opponent</th>
+			<th class="h2h-num" data-sort="wins">Record</th>
+			<th class="h2h-num" data-sort="games">Games</th>
+			<th class="h2h-num" data-sort="winPct">Win %</th>
+		</tr></thead>
 		<tbody>${rows}</tbody>
 	</table>`;
 }
@@ -86,6 +92,7 @@ async function init() {
 			}));
 		};
 
+		const sortState = { key: 'games', dir: 'desc' };
 		const renderTable = () => {
 			const venue = controls.venue.value;
 			const type = controls.type.value;
@@ -94,12 +101,13 @@ async function init() {
 				&& (type === 'all' || (type === 'regular' ? g.regular_season === '1' : g.regular_season !== '1')));
 			const data = venue === 'all' && type === 'all' ? allTime : computeHeadToHead(subset);
 			const q = controls.q.value.trim().toLowerCase();
-			const opponents = data.opponents.filter((o) =>
+			const opponents = sortItems(data.opponents.filter((o) =>
 				(!controls.current.checked || o.current)
-				&& (q === '' || o.name.toLowerCase().includes(q)));
+				&& (q === '' || o.name.toLowerCase().includes(q))), sortState);
 			wrap.innerHTML = opponents.length
 				? tableHtml(opponents)
 				: '<p class="record-empty">No opponents match those filters.</p>';
+			wireSortHeaders(wrap, sortState, renderTable);
 			const filtered = venue !== 'all' || type !== 'all' || controls.current.checked || q !== '';
 			countEl.textContent = filtered ? `${opponents.length} of ${allTime.opponents.length} opponents` : '';
 		};


### PR DESCRIPTION
## Franchise History (`/history`)
- One line, one point per season, 1921-now: win % by default (ties count half, honest across 10-game and 17-game eras). Championship seasons get gold trophy dots (1929-31 standings titles hardcoded; every later title derived as "won the season''s final playoff game" - yields exactly the 13), perfect seasons a white ring
- **Multi-metric**: plot any combination of win %, wins, points for, points against - same-scale picks share a real labeled axis (PF vs PA is a great century view), mixed scales normalize per series with exact values in tooltips
- **Include playoffs** toggle folds postseason into every metric (2010 becomes 14-6, PF 509)
- Coach-era bands span every tenure; hovering a band shows that coach''s full record, clicking opens `/coaches`. Season hover shows record + PF/PA; click opens the season
- Homepage sparkline under the answer (viewed season marked, links to `/history`) and a social card at `/og/history.png` embedding the real chart - all three render from one pure SVG builder (`history-chart.js`)
- Metric selection and playoff inclusion persist like other settings

## Head Coaches (`/coaches`)
- `data/packers_coaches.csv` holds tenures as from/to **dates**, so mid-season changes split exactly: Ronzani -> Devore/McLean with two games left in 1953, McCarthy -> Philbin after week 13 of 2018. Every game is assigned to its coach by date
- Coach numbering preserves the official count: regulars 1-15, interims fractional (Devore/McLean 2.1, Philbin 14.1); interims marked with an asterisk and excludable via a persisted toggle
- Verified against the record books: Lombardi 89-29-4 (.746), 9-1 playoffs, 5 titles; Lambeau 209-104-21, 6 titles; titles sum to 13. Championships attribute to whoever coached the champion season''s final game
- Photos from Wikimedia Commons for 12 of 17 stints, each license verified via the Commons API (PD/CC only); photos open in the site''s lightbox with a source/license link. Social card at `/og/coaches.png`

## Site-wide
- **Sortable tables**: coaches and opponents tables sort by any column (shared `sortable.js`, asc/desc + arrow)
- **Share rows unified**: main/history/coaches use one centered, labelled format; in-card rows stay compact icon-only
- **Weekday off-by-one fixed**: `new Date(''YYYY-MM-DD'')` parses UTC, showing Sunday games as Saturday in US timezones; shared `localDate()` fixes schedule dates and On This Day matching (1966 opener: Sat Sep 10; Super Bowl I: Sun Jan 15)
- **Data/code cache skew fixed**: CSVs now serve `no-cache` like unversioned modules, so column changes deploy atomically (this was the "interim filter doesn''t work" root cause - an hour-stale coaches CSV)
- Chart tooltip now tracks the cursor (was positioned against the page, not the chart)
- Past-season title includes the year: "Were the Packers Undefeated in 1996?"

## Testing
- Everything driven in a real browser against a static server: chart tooltips/metrics/playoff math, coach records vs history, interim toggle, lightbox, sorting on both tables, share rows, weekday spot-checks, persistence across reloads
- OG card layouts rendered and measured in-browser (no text overflow); node-side files parse-checked. `/history`, `/coaches`, and their `/og/*.png` routes get first live exercise on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)